### PR TITLE
width & height for vertex shapes

### DIFF
--- a/igraph/drawing/vertex.py
+++ b/igraph/drawing/vertex.py
@@ -90,8 +90,10 @@ class DefaultVertexDrawer(AbstractCairoVertexDrawer):
     def draw(self, visual_vertex, vertex, coords):
         context = self.context
         
-        if visual_vertex.width is None: visual_vertex.width = visual_vertex.size
-        if visual_vertex.height is None: visual_vertex.height = visual_vertex.width
+        if visual_vertex.width is None: 
+                visual_vertex.width = visual_vertex.size
+        if visual_vertex.height is None: 
+                visual_vertex.height = visual_vertex.width
         visual_vertex.shape.draw_path(context, \
                 coords[0], coords[1], visual_vertex.width, visual_vertex.height)
         context.set_source_rgba(*visual_vertex.color)

--- a/igraph/drawing/vertex.py
+++ b/igraph/drawing/vertex.py
@@ -83,13 +83,17 @@ class DefaultVertexDrawer(AbstractCairoVertexDrawer):
             position = dict(func=self.layout.__getitem__)
             shape = ("circle", ShapeDrawerDirectory.resolve_default)
             size  = 20.0
+            width = None
+            height = None
         return VisualVertexBuilder
 
     def draw(self, visual_vertex, vertex, coords):
         context = self.context
-
+        
+        if visual_vertex.width is None: visual_vertex.width = visual_vertex.size
+        if visual_vertex.height is None: visual_vertex.width = visual_vertex.width
         visual_vertex.shape.draw_path(context, \
-                coords[0], coords[1], visual_vertex.size)
+                coords[0], coords[1], visual_vertex.width, visual_vertex.height)
         context.set_source_rgba(*visual_vertex.color)
         context.fill_preserve()
         context.set_source_rgba(*visual_vertex.frame_color)

--- a/igraph/drawing/vertex.py
+++ b/igraph/drawing/vertex.py
@@ -91,7 +91,7 @@ class DefaultVertexDrawer(AbstractCairoVertexDrawer):
         context = self.context
         
         if visual_vertex.width is None: visual_vertex.width = visual_vertex.size
-        if visual_vertex.height is None: visual_vertex.width = visual_vertex.width
+        if visual_vertex.height is None: visual_vertex.height = visual_vertex.width
         visual_vertex.shape.draw_path(context, \
                 coords[0], coords[1], visual_vertex.width, visual_vertex.height)
         context.set_source_rgba(*visual_vertex.color)


### PR DESCRIPTION
All vertex shapes accept `width` and `height` parameters, just `VisualVertexBuilder` of `DefaultVertexDrawer` does not pass them, instead gives the value of `size` for argument `width`. This behavior is preserved, but now `width` and `height` can be used the way as it was designed seemingly.
