### PR TITLE
tweak Read_Pickle to fail gracefully (issue 40)

### DIFF
--- a/igraph/__init__.py
+++ b/igraph/__init__.py
@@ -1796,8 +1796,11 @@ class Graph(GraphBase):
             try:
                 fp = open(fname, "rb")
             except IOError:
-                # No file with the given name, try unpickling directly
-                result = pickle.loads(fname)
+                try:
+                    # No file with the given name, try unpickling directly.
+                    result = pickle.loads(fname)
+                except TypeError:
+                    raise IOError('Cannot load file. If fname is a file name, that filename may be incorrect.')
             if fp is not None:
                 result = pickle.load(fp)
                 fp.close()


### PR DESCRIPTION
Tweaks to allow for more informative error when Read_Pickle can't find a file. 