### PR TITLE
Release 0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+
+[![](https://travis-ci.org/igraph/python-igraph.svg?branch=master)](https://travis-ci.org/igraph/python-igraph)
+
+Python interface for the igraph library
+---------------------------------------
+
+igraph is a library for creating and manipulating graphs. 
+It is intended to be as powerful (ie. fast) as possible to enable the
+analysis of large graphs. 
+
+This repository contains the source code to the Python interface of
+igraph.
+
+## Install
+```
+$ sudo python setup.py install
+```
+See details in [Installing Python Modules](https://docs.python.org/2/install/).
+
+## Notes
+This version of python-igraph is ported into [pypy](http://pypy.org/) and verified on Linux Ubuntu 14.04 with default pypy.

--- a/igraph/compat.py
+++ b/igraph/compat.py
@@ -55,7 +55,8 @@ if sys.version_info < (2, 6):
             cls_ns[propname] = property(self.fget, fset, self.fdel, self.__doc__)
             return cls_ns[propname]
 else:
-    property = __builtins__["property"]
+	# Note: 'module' object is not subscriptable in PyPy, but dotted notation is portable
+    property = __builtins__.property
 
 #############################################################################
 # Providing BytesIO for Python 2.5

--- a/src/common.c
+++ b/src/common.c
@@ -55,10 +55,13 @@ PyObject* igraphmodule_unimplemented(PyObject* self, PyObject* args, PyObject* k
 PyObject* igraphmodule_resolve_graph_weakref(PyObject* ref) {
   PyObject *o;
   
+#ifndef PYPY_VERSION
+  // Not implemented in PyPy
   if (!PyWeakref_Check(ref)) {
     PyErr_SetString(PyExc_TypeError, "weak reference expected");
     return NULL;
   }
+#endif  // PYPY_VERSION
   o=PyWeakref_GetObject(ref);
   if (o == Py_None) {
     PyErr_SetString(PyExc_TypeError, "underlying graph has already been destroyed");

--- a/src/convert.c
+++ b/src/convert.c
@@ -766,6 +766,12 @@ int igraphmodule_PyObject_to_integer_t(PyObject *object, igraph_integer_t *v) {
  * \return 0 if everything was OK, 1 otherwise
  */
 int igraphmodule_PyObject_to_real_t(PyObject *object, igraph_real_t *v) {
+#ifdef PYPY_VERSION
+  // PyFloatObject is not defined in pypy, but PyFloat_AS_DOUBLE() is
+  // supported on PyObject: /pypy/module/cpyext/floatobject.py
+  typedef PyObject  PyFloatObject;
+#endif
+	
   if (object == NULL) {
   } else if (PyLong_Check(object)) {
     double d = PyLong_AsDouble(object);

--- a/src/py2compat.h
+++ b/src/py2compat.h
@@ -44,7 +44,11 @@ int PyFile_Close(PyObject* fileObj);
 
 PyObject* PyFile_FromObject(PyObject* filename, const char* mode);
 
-#define PyIntObject    PyLongObject
+#ifdef PYPY_VERSION
+  typedef PyObject  PyIntObject;
+#else
+  typedef PyLongObject  PyIntObject;
+#endif  // PYPY_VERSION
 #define PyInt_AsLong   PyLong_AsLong
 #define PyInt_Check    PyLong_Check
 #define PyInt_FromLong PyLong_FromLong


### PR DESCRIPTION
python-igraph release 0.7 is ported to PyPy!

There was an issue [Error installing python-igraph using pip with pypy](https://github.com/igraph/igraph/issues/861) and this is the solution!

I compiled it on Ubuntu 14.04 and worked fine on default pypy:
```
Python 2.7.3 (2.2.1+dfsg-1ubuntu0.3, Sep 30 2015, 15:18:40)
[PyPy 2.2.1 with GCC 4.8.4]
```