### PR TITLE
fix keyword parsing bug in decompose()

### DIFF
--- a/src/graphobject.c
+++ b/src/graphobject.c
@@ -4117,7 +4117,7 @@ PyObject *igraphmodule_Graph_decompose(igraphmodule_GraphObject * self,
   igraph_vector_ptr_t components;
   igraph_t *g;
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|Oll", kwlist, &mode,
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|Oll", kwlist, &mode_o,
                                    &maxcompno, &minelements))
     return NULL;
 


### PR DESCRIPTION
An easy-to-fix bug in keyword argument parsing makes it impossible to run decompose() on directed graphs 