### PR TITLE
Decode SVG representation as string for IPython.

### DIFF
--- a/igraph/drawing/__init__.py
+++ b/igraph/drawing/__init__.py
@@ -355,7 +355,7 @@ class Plot(object):
         if hasattr(result, "encode"):
             return result.encode("utf-8")     # for Python 2.x
         else:
-            return result                     # for Python 3.x
+            return result.decode("utf-8")     # for Python 3.x
 
     @property
     def bounding_box(self):


### PR DESCRIPTION
Plotting in IPython is currently broken.

The `_repr_svg` method of `Plot` checks for Python2 vs. Python3 and encodes into a UTF-8 str in the former case, but leaves the return value as `bytes` in the latter. However IPython expects the result to be a string. Decoding the bytes into a UTF-8 string fixes this and shows the plot in IPython.
