### PR TITLE
Added .gitattributes to ensure correct language tagging of repo (as P…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.c linguist-language=Python


### PR DESCRIPTION
My fork is incorrectly tagged as  C repo by GitHub - I've just added a `.gitattributes` file to correct this.