### PR TITLE
Isolate graph drawing result to avoid id collision

### DIFF
--- a/igraph/drawing/__init__.py
+++ b/igraph/drawing/__init__.py
@@ -356,9 +356,11 @@ class Plot(object):
         # Return the raw SVG representation
         result = io.getvalue()
         if hasattr(result, "encode"):
-            return result.encode("utf-8")     # for Python 2.x
+            result = result.encode("utf-8")   # for Python 2.x
         else:
-            return result.decode("utf-8")     # for Python 3.x
+            result = result.decode("utf-8")   # for Python 3.x
+
+        return result, {'isolated': True}  # put it inside an iframe
 
     @property
     def bounding_box(self):


### PR DESCRIPTION
fixes #145

This change which is suggested by @takluyver forces jupyter to isolate
graphs inside a notebook so we won't have collision of similar ids
can be available on cairo renderer.