### PR TITLE
Improve _is_running_in_ipython logic, fixes #149

### DIFF
--- a/igraph/utils.py
+++ b/igraph/utils.py
@@ -39,11 +39,9 @@ def _is_running_in_ipython():
     """Internal function that determines whether igraph is running inside
     IPython or not."""
     try:
-        # get_ipython is injected into the Python builtins by IPython so
-        # this should succeed in IPython but throw a NameError otherwise
-        get_ipython
-        return True
-    except NameError:
+        from IPython import get_ipython
+        return get_ipython() is not None
+    except ImportError:
         return False
 
 


### PR DESCRIPTION
For some reasons it seems the current code is not able to detect ipython
when ran from ipywidgets interactive widgets, lets change it to
what @takluyver from jupyter team is suggested below:

https://github.com/jupyter/jupyter/issues/299#issuecomment-344540261