### PR TITLE
remove redundant definition of TextAlignment

### DIFF
--- a/igraph/drawing/text.py
+++ b/igraph/drawing/text.py
@@ -25,14 +25,6 @@ class TextAlignment(object):
 
 #####################################################################
 
-class TextAlignment(object):
-    """Text alignment constants."""
-
-    LEFT, CENTER, RIGHT = "left", "center", "right"
-    TOP, BOTTOM = "top", "bottom"
-
-#####################################################################
-
 class TextDrawer(AbstractCairoDrawer):
     """Class that draws text on a Cairo context.
 


### PR DESCRIPTION
the `class TextAlignment` was repeated in the code