### PR TITLE
Fix wrong variable substitution Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TAG = igraph/manylinux
 
 build-wheel:
-	docker build -f docker/manylinux.docker -t $TAG .
+	docker build -f docker/manylinux.docker -t $(TAG) .
 
 copy-wheel:
 	rm -rf docker/wheelhouse


### PR DESCRIPTION
A variable substitution in the Makefile was missing parentheses which stopped the variable from being substituted correctly. This lead to docker being called with "docker build -f docker/manylinux.docker -t AG", which is obviously unintended.

