### PR TITLE
Add support for coloring to BLISS functions

### DIFF
--- a/igraph/test/isomorphism.py
+++ b/igraph/test/isomorphism.py
@@ -43,6 +43,19 @@ class IsomorphismTests(unittest.TestCase):
         g2.vs["color"] = [0,0,1,1,0,1,1,0]
         self.assertTrue(not g1.isomorphic_vf2(g2, "color", "color"))
 
+        # Test bliss with colors
+        self.assertTrue(g1.isomorphic_bliss(g2,
+                                            color1=[0,0,0,0,0,0,0,0],
+                                            color2=[0,0,0,0,0,0,0,0]))
+
+        self.assertTrue(g1.isomorphic_bliss(g2,
+                                            color1=[1,0,2,0,0,0,0,0],
+                                            color2=[1,0,2,0,0,0,0,0]))
+
+        self.assertTrue(g1.isomorphic_bliss(g2,
+                                            color1=[0,1,0,1,0,1,0,1],
+                                            color2=[0,0,1,1,0,0,1,1]))
+
         # Test VF2 with vertex and edge colors
         self.assertTrue(g1.isomorphic_vf2(g2,
             color1=[0,1,0,1,0,1,0,1],
@@ -231,6 +244,17 @@ class PermutationTests(unittest.TestCase):
 
         self.assertTrue(g3.vcount() == g4.vcount())
         self.assertTrue(sorted(g3.get_edgelist()) == sorted(g4.get_edgelist()))
+
+        # Simple case with coloring
+        cp = g1.canonical_permutation(color = [0, 0, 1, 1])
+        g3 = g1.permute_vertices(cp)
+
+        cp = g2.canonical_permutation(color = [0, 0, 1, 1])
+        g4 = g2.permute_vertices(cp)
+
+        self.assertTrue(g3.vcount() == g4.vcount())
+        self.assertTrue(sorted(g3.get_edgelist()) == sorted(g4.get_edgelist()))
+
 
         # More complicated one: small GRG, random permutation
         g = Graph.GRG(10, 0.5)


### PR DESCRIPTION
Although the functions for computing canonical permuations
and testing isomorphism using BLISS in igraph's C core
support colorings, this support is not exposed in the
python library.

This commit adds support for colorings to the
corresponding functions of the python library.

*Beware:* The tests should succeed after PR #1117 has been merged into the igraph  C core