### PR TITLE
Alternative installation/compilation method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ igraph/*.so
 .tox
 docker/wheelhouse
 Pipfile
-
+src/core

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,35 @@
+cd vendor/source/igraph/
+
+#./bootstrap.sh
+#./configure --disable-tls --disable-gmp
+#make
+
+cd src/
+
+SOURCES=`make echodist | head -1`
+SOURCES="$SOURCES ../config.h f2c/arith.h"
+headerfile=""
+for file in $SOURCES ; do
+    if [[ $file == *.y ]]; then
+        file="${file%.y}.c"
+        headerfile="${file%.c}.h"
+    elif [[ $file == *.l ]]; then
+        file="${file%.l}.c"
+    fi
+    if [[ $file == *.c ]] || [[ $file == *.cc ]] || [[ $file == *.cpp ]] || [[ $file == *.h ]] || [[ $file = *.hh ]] || [[ $file == *.pmt ]]
+    then
+        dir=$(dirname "$file")
+        mkdir -p "../../../../src/core/src/$dir"
+        cp "$file" "../../../../src/core/src/$file"
+        echo "Copy $file"
+        if [ -n "$headerfile" ]; then
+            cp "$headerfile" "../../../../src/core/src/$headerfile"
+            echo "Copy $headerfile"
+        fi
+    else
+        echo "Ignoring $file"
+    fi
+    headerfile=""
+done
+
+cd ../../../../

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,8 +1,8 @@
 cd vendor/source/igraph/
 
-#./bootstrap.sh
-#./configure --disable-tls --disable-gmp
-#make
+./bootstrap.sh
+./configure
+make
 
 cd src/
 


### PR DESCRIPTION
This is an alternative installation method that I have in mind. The idea is that all necessary C code will be immediately included in the Python extension, instead of compiled separately as a library and then linked against. The `setup.py` is still a bit rough, and should be carefully checked, but it illustrates the idea.

The new file `bootstrap.sh` pulls all necessary sources from `vendor/source/igraph` and puts them in `src/core`. It relies on a new addition to `src/Makefile.am` in the `igraph` C core:
```
echodist: 
	$(info $(DISTFILES))
```
This allows `bootstrap.sh` to parse all necessary files and copy them over to `src/core`. Since I cannot refer to a specific commit in `igraph` for the submodule in `vendor/source/igraph` that includes this change (yet), the compilation on the CI systems will inevitably fail. The commit from `igraph` that I use for the submodule is https://github.com/igraph/igraph/commit/77daf8c3018f7d4302d3eecd38e92d6bd521dbca, with the added change to `src/Makefile.am` as indicated.

The new `setup.py` will by default simply compile all source files. The great benefit of doing it this way is that we can distribute a source package using `python setup.py build sdist`, which can then be compiled on all platforms relatively straightforward. It still requires to link to `xml2`, `z`, `m` and `gmp` (note that `gmp` should be replaced by `MPIR` on Windows). On most *nix systems, this should be quite straightforward. On Windows this is more challenging, but we should ensure precompiled binaries are available for Windows anyway. I think that installation and compilation would be simpler for most users in this case.

By including all necessary source code for the Python package in the source package, there will also be less ambiguity about compiling against the "correct" version of the `igraph` C core. The Python package no longer depends on a specific released version of the `igraph` C core, thus decoupling the release of the C core and the Python package. I think we can then be more flexible with both packages and make more regular releases.

It would still be possible to compile against an external `igraph` C core library by using `--with-external-igraph`. If specific compilation things are required for some systems or for some special cases, this would then still be possible. It would also still allow to use external libraries for the `igraph` C core (e.g. the external `glpk`). The vast majority of the users will probably not need this, but it would allow expert users to still fully configure the package.

Note that the current `setup.py` still contains some dirty things to get it to work on my machine. This should of course be corrected. Some other things may better be done differently, any comment is welcome!

I just wanted to open this PR so that we can discuss more easily about the possible benefits/downsides of this alternative approach.