### PR TITLE
expose SKIP_H_INSTALL, add missing deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See details in [Installing Python Modules](https://docs.python.org/2/install/).
 
 Install dependencies
 ```
-$ sudo apt install build-essential python-dev libxml2 libxml2-dev zlib1g-dev
+$ sudo apt install build-essential python-dev libxml2 libxml2-dev zlib1g-dev bison
 ```
 and then
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See details in [Installing Python Modules](https://docs.python.org/2/install/).
 
 Install dependencies
 ```
-$ sudo apt install build-essential python-dev libxml2 libxml2-dev zlib1g-dev bison
+$ sudo apt install build-essential python-dev libxml2 libxml2-dev zlib1g-dev bison flex
 ```
 and then
 ```

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ TESTING_IN_CI = "CONTINUOUS_INTEGRATION" in os.environ
 
 # Check whether we are compiling for PyPy. Headers will not be installed
 # for PyPy.
-SKIP_H_INSTALL = (platform.python_implementation() == "PyPy") or ("SKIP_H_INSTALL" in os.environ)
+SKIP_HEADER_INSTALL = (platform.python_implementation() == "PyPy") or ("SKIP_HEADER_INSTALL" in os.environ)
 
 ###########################################################################
 # Here be ugly workarounds. These must be run before setuptools
@@ -1000,7 +1000,7 @@ versions can also be found `here <http://www.lfd.uci.edu/~gohlke/pythonlibs>`_.
 Many thanks to the maintainers of this page!
 """
 
-headers = ["src/igraphmodule_api.h"] if not SKIP_H_INSTALL else []
+headers = ["src/igraphmodule_api.h"] if not SKIP_HEADER_INSTALL else []
 
 options = dict(
     name="python-igraph",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ TESTING_IN_CI = "CONTINUOUS_INTEGRATION" in os.environ
 
 # Check whether we are compiling for PyPy. Headers will not be installed
 # for PyPy.
-IS_PYPY = platform.python_implementation() == "PyPy"
+SKIP_H_INSTALL = (platform.python_implementation() == "PyPy") or ("SKIP_H_INSTALL" in os.environ)
 
 ###########################################################################
 # Here be ugly workarounds. These must be run before setuptools
@@ -1000,7 +1000,7 @@ versions can also be found `here <http://www.lfd.uci.edu/~gohlke/pythonlibs>`_.
 Many thanks to the maintainers of this page!
 """
 
-headers = ["src/igraphmodule_api.h"] if not IS_PYPY else []
+headers = ["src/igraphmodule_api.h"] if not SKIP_H_INSTALL else []
 
 options = dict(
     name="python-igraph",


### PR DESCRIPTION
- [x] add `SKIP_H_INSTALL` env var to avoid `setup.py` installing headers
- [x] document `apt install bison`
- [x] document `apt install flex`