### PR TITLE
Add adjacency sparse export as separate function

### DIFF
--- a/igraph/__init__.py
+++ b/igraph/__init__.py
@@ -57,7 +57,6 @@ from collections import defaultdict
 from itertools import izip
 from shutil import copyfileobj
 from warnings import warn
-import numpy as np
 from scipy.sparse import csr_matrix
 
 def deprecated(message):
@@ -541,7 +540,7 @@ class Graph(GraphBase):
 
         edges = self.get_edgelist()
         if attribute is None:
-            weights = np.ones(len(edges))
+            weights = [1] * len(edges)
         else:
             if attribute not in self.es.attribute_names():
                 raise ValueError("Attribute does not exist")

--- a/igraph/__init__.py
+++ b/igraph/__init__.py
@@ -539,16 +539,13 @@ class Graph(GraphBase):
           given attribute where there is an edge.
         @return: the adjacency matrix as a L{scipy.sparse.csr_matrix}."""
 
-        if attribute is None:
-            return Matrix(GraphBase.get_adjacency(self, type))
-
-        if attribute not in self.es.attribute_names():
-            raise ValueError("Attribute does not exist")
-
         edges = self.get_edgelist()
         if attribute is None:
             weights = np.ones(len(edges))
         else:
+            if attribute not in self.es.attribute_names():
+                raise ValueError("Attribute does not exist")
+
             weights = self.es[attribute]
 
         N = self.vcount()


### PR DESCRIPTION
As was requested in #72 
I think it's better to make it a separate function, because otherwise all added code will appear in `if sparse:` block. Moreover `get_adjacency` is already too long.

I have used @ntamas example code as base, but have added some speedup: 
Original code gives `1.94 s ± 4.45 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`
My speedup: `1.01 s ± 4.33 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`
Tested on iMDB recommendations graph with ~173K nodes and ~1568K edges.
There was also a little bug in example: sparse matrix constructor is not aware about matrix shape, so it must be provided explicitly.