### PR TITLE
Weighted incidence

### DIFF
--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -2825,15 +2825,19 @@ class Graph(GraphBase):
           weighted argument. If it is C{True} then a weighted graph is created and
           the name of the edge attribute will be ‘weight’.
 
+        @raise ValueError: if the weighted and multiple are passed together.
+
         @return: the graph with a binary vertex attribute named C{"type"} that
           stores the vertex classes.
         """
         weighted = kwds.pop("weighted", False)
-        if weighted:
-          kwds["multiple"] = False
+        is_weighted = True if weighted or weighted == "" else False
+        multiple = kwds.get("multiple", False)
+        if is_weighted and multiple:
+            raise ValueError("arguments weighted and multiple can not co-exist")
         result, types = klass._Incidence(*args, **kwds)
         result.vs["type"] = types
-        if weighted:
+        if is_weighted:
             weight_attr = "weight" if weighted == True else weighted
             mat = args[0]
             _, rows, columns = result.get_incidence()

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -2822,6 +2822,8 @@ class Graph(GraphBase):
           stores the vertex classes.
         """
         weighted = kwds.pop("weighted", False)
+        if weighted:
+          kwds["multiple"] = False
         result, types = klass._Incidence(*args, **kwds)
         if weighted:
             mat = args[0]

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -2821,20 +2821,16 @@ class Graph(GraphBase):
         @return: the graph with a binary vertex attribute named C{"type"} that
           stores the vertex classes.
         """
-        weighted = kwds.pop('weighted', False)
+        weighted = kwds.pop("weighted", False)
         result, types = klass._Incidence(*args, **kwds)
         if weighted:
-          weight_attr = 'weight' if weighted == True else weighted
-          result.es[weight_attr] = 1
-          mat = args[0]
-          for i, weights in enumerate(mat):
-            for j, weight in enumerate(weights):
-              if weight:
-                source = i
-                target = len(mat) + j
-                eid = result.get_eid(source, target)
-                result.es[eid][weight_attr] = weight
-          # result = kclass._add_weights(args[0], weighted, result)
+            mat = args[0]
+            weight_attr = "weight" if weighted == True else weighted
+            result.es[weight_attr] = 1
+            for edge in result.es:
+                source, target = edge.tuple
+                row, column = source, target - len(mat)
+                edge[weight_attr] = mat[row][column]
         result.vs["type"] = types
         return result
 

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -2820,10 +2820,10 @@ class Graph(GraphBase):
         @param weighted: defines whether to create a weighted graph from the
           incidence matrix. If it is c{None} then an unweighted graph is created
           and the multiple argument is used to determine the edges of the graph.
-          If it is a character constant then for every non-zero matrix entry, an
-          edge is created and the value of the entry is added as an edge attribute
-          named by the weighted argument. If it is C{True} then a weighted graph
-          is created and the name of the edge attribute will be ‘weight’.
+          If it is a string then for every non-zero matrix entry, an edge is created
+          and the value of the entry is added as an edge attribute named by the
+          weighted argument. If it is C{True} then a weighted graph is created and
+          the name of the edge attribute will be ‘weight’.
 
         @return: the graph with a binary vertex attribute named C{"type"} that
           stores the vertex classes.
@@ -2837,12 +2837,13 @@ class Graph(GraphBase):
             weight_attr = "weight" if weighted == True else weighted
             mat = args[0]
             _, rows, columns = result.get_incidence()
+            num_vertices_of_first_kind = len(rows)
             for edge in result.es:
                 source, target = edge.tuple
                 if source in rows:
-                    edge[weight_attr] = mat[source][target - len(rows)]
+                    edge[weight_attr] = mat[source][target - num_vertices_of_first_kind]
                 else:
-                    edge[weight_attr] = mat[target][source - len(rows)]
+                    edge[weight_attr] = mat[target][source - num_vertices_of_first_kind]
         return result
 
     def bipartite_projection(self, types="type", multiplicity=True, probe1=-1,

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -2821,7 +2821,20 @@ class Graph(GraphBase):
         @return: the graph with a binary vertex attribute named C{"type"} that
           stores the vertex classes.
         """
+        weighted = kwds.pop('weighted', False)
         result, types = klass._Incidence(*args, **kwds)
+        if weighted:
+          weight_attr = 'weight' if weighted == True else weighted
+          result.es[weight_attr] = 1
+          mat = args[0]
+          for i, weights in enumerate(mat):
+            for j, weight in enumerate(weights):
+              if weight:
+                source = i
+                target = len(mat) + j
+                eid = result.get_eid(source, target)
+                result.es[eid][weight_attr] = weight
+          # result = kclass._add_weights(args[0], weighted, result)
         result.vs["type"] = types
         return result
 

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -2831,7 +2831,10 @@ class Graph(GraphBase):
             result.es[weight_attr] = 1
             for edge in result.es:
                 source, target = edge.tuple
-                row, column = source, target - len(mat)
+                if result.is_directed() and kwds.get("mode", "out") == "in":
+                    row, column = target, source - len(mat)
+                else:
+                    row, column = source, target - len(mat)
                 edge[weight_attr] = mat[row][column]
         result.vs["type"] = types
         return result

--- a/tests/test_bipartite.py
+++ b/tests/test_bipartite.py
@@ -88,6 +88,13 @@ class BipartiteTests(unittest.TestCase):
         self.assertListEqual(g.es['weight'], [1, 1, 1, 2])
         self.assertTrue(sorted(g.get_edgelist()) == [(2, 1), (3, 0), (3, 1), (4, 0)])
 
+        # Should work when directed=True and mode=all with weighted
+        g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], directed=True, mode="all", weighted=True)
+        self.assertTrue(all((g.vcount() == 5, g.ecount() == 8, g.is_directed(), g.is_weighted())))
+        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
+        self.assertListEqual(g.es['weight'], [1, 1, 1, 1, 1, 1, 2, 2])
+        self.assertTrue(sorted(g.get_edgelist()) == [(0, 3), (0, 4), (1, 2), (1, 3), (2, 1), (3, 0), (3, 1), (4, 0)])
+
     def testGetIncidence(self):
         mat = [[0, 1, 1], [1, 1, 0]]
         v1, v2 = [0, 1], [2, 3, 4]

--- a/tests/test_bipartite.py
+++ b/tests/test_bipartite.py
@@ -61,17 +61,17 @@ class BipartiteTests(unittest.TestCase):
         self.assertListEqual(sorted(g.get_edgelist()), [(0, 3), (0, 4), (1, 2),(1,3)])
 
         # Graph is not weighted when weighted=`str`
-        g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], weighted='some_attr_name')
+        g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], weighted="some_attr_name")
         self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, not g.is_directed(), not g.is_weighted())))
         self.assertListEqual(g.vs["type"], [False]*2 + [True]*3)
-        self.assertListEqual(g.es['some_attr_name'], [1, 1, 1, 2])
+        self.assertListEqual(g.es["some_attr_name"], [1, 1, 1, 2])
         self.assertListEqual(sorted(g.get_edgelist()), [(0, 3), (0, 4), (1, 2),(1,3)])
 
-        # Ignore multiple when passed `weighted`
-        g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], multiple=True, weighted=True)
-        self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, not g.is_directed(), g.is_weighted())))
+        # Graph is not weighted when weighted=""
+        g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], weighted="")
+        self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, not g.is_directed(), not g.is_weighted())))
         self.assertListEqual(g.vs["type"], [False]*2 + [True]*3)
-        self.assertListEqual(g.es["weight"], [1, 1, 1, 2])
+        self.assertListEqual(g.es[""], [1, 1, 1, 2])
         self.assertListEqual(sorted(g.get_edgelist()), [(0, 3), (0, 4), (1, 2),(1,3)])
 
         # Should work when directed=True and mode=out with weighted
@@ -94,6 +94,17 @@ class BipartiteTests(unittest.TestCase):
         self.assertListEqual(g.vs["type"], [False]*2 + [True]*3)
         self.assertListEqual(g.es["weight"], [1, 1, 1, 1, 1, 1, 2, 2])
         self.assertListEqual(sorted(g.get_edgelist()), [(0, 3), (0, 4), (1, 2), (1, 3), (2, 1), (3, 0), (3, 1), (4, 0)])
+
+    def testIncidenceError(self):
+        msg = "arguments weighted and multiple can not co-exist"
+        with self.assertRaisesRegex(ValueError, msg) as e:
+            Graph.Incidence([[0, 1, 1], [1, 2, 0]], multiple=True, weighted=True)
+
+        with self.assertRaisesRegex(ValueError, msg) as e:
+            Graph.Incidence([[0, 1, 1], [1, 2, 0]], multiple=True, weighted="string")
+
+        with self.assertRaisesRegex(ValueError, msg) as e:
+            Graph.Incidence([[0, 1, 1], [1, 2, 0]], multiple=True, weighted="")
 
     def testGetIncidence(self):
         mat = [[0, 1, 1], [1, 1, 0]]

--- a/tests/test_bipartite.py
+++ b/tests/test_bipartite.py
@@ -34,66 +34,66 @@ class BipartiteTests(unittest.TestCase):
 
     def testIncidence(self):
         g = Graph.Incidence([[0, 1, 1], [1, 2, 0]])
-        self.assertTrue(g.vcount() == 5 and g.ecount() == 4 and g.is_directed() == False)
-        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
-        self.assertTrue(sorted(g.get_edgelist()) == [(0,3),(0,4),(1,2),(1,3)])
+        self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, not g.is_directed())))
+        self.assertListEqual(g.vs["type"], [False]*2 + [True]*3)
+        self.assertListEqual(sorted(g.get_edgelist()), [(0,3),(0,4),(1,2),(1,3)])
 
         g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], multiple=True)
-        self.assertTrue(g.vcount() == 5 and g.ecount() == 5 and g.is_directed() == False)
-        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
-        self.assertTrue(sorted(g.get_edgelist()) == [(0,3),(0,4),(1,2),(1,3),(1,3)])
+        self.assertTrue(all((g.vcount() == 5, g.ecount() == 5, not g.is_directed())))
+        self.assertListEqual(g.vs["type"], [False]*2 + [True]*3)
+        self.assertListEqual(sorted(g.get_edgelist()), [(0,3),(0,4),(1,2),(1,3),(1,3)])
 
         g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], directed=True)
-        self.assertTrue(g.vcount() == 5 and g.ecount() == 4 and g.is_directed() == True)
-        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
-        self.assertTrue(sorted(g.get_edgelist()) == [(0,3),(0,4),(1,2),(1,3)])
+        self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, g.is_directed())))
+        self.assertListEqual(g.vs["type"], [False]*2 + [True]*3)
+        self.assertListEqual(sorted(g.get_edgelist()), [(0,3),(0,4),(1,2),(1,3)])
 
         g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], directed=True, mode="in")
-        self.assertTrue(g.vcount() == 5 and g.ecount() == 4 and g.is_directed() == True)
-        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
-        self.assertTrue(sorted(g.get_edgelist()) == [(2,1),(3,0),(3,1),(4,0)])
+        self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, g.is_directed())))
+        self.assertListEqual(g.vs["type"], [False]*2 + [True]*3)
+        self.assertListEqual(sorted(g.get_edgelist()), [(2,1),(3,0),(3,1),(4,0)])
 
         # Create a weighted Graph
         g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], weighted=True)
         self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, not g.is_directed(), g.is_weighted())))
-        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
-        self.assertListEqual(g.es['weight'], [1, 1, 1, 2])
-        self.assertTrue(sorted(g.get_edgelist()) == [(0, 3), (0, 4), (1, 2),(1,3)])
+        self.assertListEqual(g.vs["type"], [False]*2 + [True]*3)
+        self.assertListEqual(g.es["weight"], [1, 1, 1, 2])
+        self.assertListEqual(sorted(g.get_edgelist()), [(0, 3), (0, 4), (1, 2),(1,3)])
 
         # Graph is not weighted when weighted=`str`
         g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], weighted='some_attr_name')
         self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, not g.is_directed(), not g.is_weighted())))
-        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
+        self.assertListEqual(g.vs["type"], [False]*2 + [True]*3)
         self.assertListEqual(g.es['some_attr_name'], [1, 1, 1, 2])
-        self.assertTrue(sorted(g.get_edgelist()) == [(0, 3), (0, 4), (1, 2),(1,3)])
+        self.assertListEqual(sorted(g.get_edgelist()), [(0, 3), (0, 4), (1, 2),(1,3)])
 
         # Ignore multiple when passed `weighted`
         g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], multiple=True, weighted=True)
         self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, not g.is_directed(), g.is_weighted())))
-        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
-        self.assertListEqual(g.es['weight'], [1, 1, 1, 2])
-        self.assertTrue(sorted(g.get_edgelist()) == [(0, 3), (0, 4), (1, 2),(1,3)])
+        self.assertListEqual(g.vs["type"], [False]*2 + [True]*3)
+        self.assertListEqual(g.es["weight"], [1, 1, 1, 2])
+        self.assertListEqual(sorted(g.get_edgelist()), [(0, 3), (0, 4), (1, 2),(1,3)])
 
         # Should work when directed=True and mode=out with weighted
         g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], directed=True, weighted=True)
         self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, g.is_directed(), g.is_weighted())))
-        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
-        self.assertListEqual(g.es['weight'], [1, 1, 1, 2])
-        self.assertTrue(sorted(g.get_edgelist()) == [(0, 3), (0, 4), (1, 2),(1,3)])
+        self.assertListEqual(g.vs["type"], [False]*2 + [True]*3)
+        self.assertListEqual(g.es["weight"], [1, 1, 1, 2])
+        self.assertListEqual(sorted(g.get_edgelist()), [(0, 3), (0, 4), (1, 2),(1,3)])
 
         # Should work when directed=True and mode=in with weighted
         g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], directed=True, mode="in", weighted=True)
         self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, g.is_directed(), g.is_weighted())))
-        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
-        self.assertListEqual(g.es['weight'], [1, 1, 1, 2])
-        self.assertTrue(sorted(g.get_edgelist()) == [(2, 1), (3, 0), (3, 1), (4, 0)])
+        self.assertListEqual(g.vs["type"], [False]*2 + [True]*3)
+        self.assertListEqual(g.es["weight"], [1, 1, 1, 2])
+        self.assertListEqual(sorted(g.get_edgelist()), [(2, 1), (3, 0), (3, 1), (4, 0)])
 
         # Should work when directed=True and mode=all with weighted
         g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], directed=True, mode="all", weighted=True)
         self.assertTrue(all((g.vcount() == 5, g.ecount() == 8, g.is_directed(), g.is_weighted())))
-        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
-        self.assertListEqual(g.es['weight'], [1, 1, 1, 1, 1, 1, 2, 2])
-        self.assertTrue(sorted(g.get_edgelist()) == [(0, 3), (0, 4), (1, 2), (1, 3), (2, 1), (3, 0), (3, 1), (4, 0)])
+        self.assertListEqual(g.vs["type"], [False]*2 + [True]*3)
+        self.assertListEqual(g.es["weight"], [1, 1, 1, 1, 1, 1, 2, 2])
+        self.assertListEqual(sorted(g.get_edgelist()), [(0, 3), (0, 4), (1, 2), (1, 3), (2, 1), (3, 0), (3, 1), (4, 0)])
 
     def testGetIncidence(self):
         mat = [[0, 1, 1], [1, 1, 0]]

--- a/tests/test_bipartite.py
+++ b/tests/test_bipartite.py
@@ -60,7 +60,14 @@ class BipartiteTests(unittest.TestCase):
         self.assertListEqual(g.es['weight'], [1, 1, 1, 2])
         self.assertTrue(sorted(g.get_edgelist()) == [(0, 3), (0, 4), (1, 2),(1,3)])
 
-        # Ignore multiple when weighted=True
+        # Graph is not weighted when weighted=`str`
+        g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], weighted='some_attr_name')
+        self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, not g.is_directed(), not g.is_weighted())))
+        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
+        self.assertListEqual(g.es['some_attr_name'], [1, 1, 1, 2])
+        self.assertTrue(sorted(g.get_edgelist()) == [(0, 3), (0, 4), (1, 2),(1,3)])
+
+        # Ignore multiple when passed `weighted`
         g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], multiple=True, weighted=True)
         self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, not g.is_directed(), g.is_weighted())))
         self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)

--- a/tests/test_bipartite.py
+++ b/tests/test_bipartite.py
@@ -74,6 +74,19 @@ class BipartiteTests(unittest.TestCase):
         self.assertListEqual(g.es['weight'], [1, 1, 1, 2])
         self.assertTrue(sorted(g.get_edgelist()) == [(0, 3), (0, 4), (1, 2),(1,3)])
 
+        # Should work when directed=True and mode=out with weighted
+        g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], directed=True, weighted=True)
+        self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, g.is_directed(), g.is_weighted())))
+        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
+        self.assertListEqual(g.es['weight'], [1, 1, 1, 2])
+        self.assertTrue(sorted(g.get_edgelist()) == [(0, 3), (0, 4), (1, 2),(1,3)])
+
+        # Should work when directed=True and mode=in with weighted
+        g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], directed=True, mode="in", weighted=True)
+        self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, g.is_directed(), g.is_weighted())))
+        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
+        self.assertListEqual(g.es['weight'], [1, 1, 1, 2])
+        self.assertTrue(sorted(g.get_edgelist()) == [(2, 1), (3, 0), (3, 1), (4, 0)])
 
     def testGetIncidence(self):
         mat = [[0, 1, 1], [1, 1, 0]]

--- a/tests/test_bipartite.py
+++ b/tests/test_bipartite.py
@@ -53,6 +53,14 @@ class BipartiteTests(unittest.TestCase):
         self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
         self.assertTrue(sorted(g.get_edgelist()) == [(2,1),(3,0),(3,1),(4,0)])
 
+        # Create a weighted Graph
+        g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], weighted=True)
+        self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, not g.is_directed(), g.is_weighted())))
+        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
+        self.assertListEqual(g.es['weight'], [1, 1, 1, 2])
+        self.assertTrue(sorted(g.get_edgelist()) == [(0, 3), (0, 4), (1, 2),(1,3)])
+
+
     def testGetIncidence(self):
         mat = [[0, 1, 1], [1, 1, 0]]
         v1, v2 = [0, 1], [2, 3, 4]

--- a/tests/test_bipartite.py
+++ b/tests/test_bipartite.py
@@ -60,6 +60,13 @@ class BipartiteTests(unittest.TestCase):
         self.assertListEqual(g.es['weight'], [1, 1, 1, 2])
         self.assertTrue(sorted(g.get_edgelist()) == [(0, 3), (0, 4), (1, 2),(1,3)])
 
+        # Ignore multiple when weighted=True
+        g = Graph.Incidence([[0, 1, 1], [1, 2, 0]], multiple=True, weighted=True)
+        self.assertTrue(all((g.vcount() == 5, g.ecount() == 4, not g.is_directed(), g.is_weighted())))
+        self.assertTrue(g.vs["type"] == [False]*2 + [True]*3)
+        self.assertListEqual(g.es['weight'], [1, 1, 1, 2])
+        self.assertTrue(sorted(g.get_edgelist()) == [(0, 3), (0, 4), (1, 2),(1,3)])
+
 
     def testGetIncidence(self):
         mat = [[0, 1, 1], [1, 1, 0]]

--- a/tests/test_bipartite.py
+++ b/tests/test_bipartite.py
@@ -97,14 +97,17 @@ class BipartiteTests(unittest.TestCase):
 
     def testIncidenceError(self):
         msg = "arguments weighted and multiple can not co-exist"
-        with self.assertRaisesRegex(ValueError, msg) as e:
+        with self.assertRaises(ValueError) as e:
             Graph.Incidence([[0, 1, 1], [1, 2, 0]], multiple=True, weighted=True)
+        self.assertIn(msg, e.exception.args)
 
-        with self.assertRaisesRegex(ValueError, msg) as e:
+        with self.assertRaises(ValueError) as e:
             Graph.Incidence([[0, 1, 1], [1, 2, 0]], multiple=True, weighted="string")
+        self.assertIn(msg, e.exception.args)
 
-        with self.assertRaisesRegex(ValueError, msg) as e:
+        with self.assertRaises(ValueError) as e:
             Graph.Incidence([[0, 1, 1], [1, 2, 0]], multiple=True, weighted="")
+        self.assertIn(msg, e.exception.args)
 
     def testGetIncidence(self):
         mat = [[0, 1, 1], [1, 1, 0]]


### PR DESCRIPTION
Fixes Issue: #229 

I have handled following cases w.r.t permutations of params:

- [x]  Allow empty str as weighted attr name
- [x]  Raise `ValueError` when multiple and weighted can not co-exist.
- [x] `weighted=True` graph becomes weighted with edge_attr=`weight`
- [x] `weighted="some_str"` graph is un-weighted with edge_attr=`some_str`
- [x] `directed=True, mode="out", weighted=True` graph is weighted, direction `out` is respcted
- [x] `directed=True, mode="in", weighted=True` graph is weighted, direction `in` is respcted
- [x] `directed=True, mode="all", weighted=True` graph is weighted, direction `all` is respcted