### PR TITLE
Clarified and corrected negative number of iterations in Leiden algorithm

### DIFF
--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -11753,7 +11753,7 @@ PyObject *igraphmodule_Graph_community_leiden(igraphmodule_GraphObject *self,
 
   static char *kwlist[] = {"edge_weights", "node_weights", "resolution_parameter",
                            "normalize_resolution", "beta", "initial_membership", "n_iterations", NULL};
-  
+
   PyObject *edge_weights_o = Py_None;
   PyObject *node_weights_o = Py_None;
   PyObject *initial_membership_o = Py_None;
@@ -11823,12 +11823,12 @@ PyObject *igraphmodule_Graph_community_leiden(igraphmodule_GraphObject *self,
         }
       }
     }
-    resolution_parameter /= igraph_vector_sum(node_weights); 
+    resolution_parameter /= igraph_vector_sum(node_weights);
   }
 
   /* Run actual Leiden algorithm for several iterations. */
   if (!error) {
-    if (n_iterations > 0) {
+    if (n_iterations >= 0) {
       for (i = 0; !error && i < n_iterations; i++) {
         error = igraph_community_leiden(&self->g,
                                         edge_weights, node_weights,
@@ -11839,13 +11839,13 @@ PyObject *igraphmodule_Graph_community_leiden(igraphmodule_GraphObject *self,
       }
     } else {
       while (!error && prev_quality < quality) {
+        prev_quality = quality;
         error = igraph_community_leiden(&self->g,
                                         edge_weights, node_weights,
                                         resolution_parameter, beta,
                                         start, membership,
                                         &nb_clusters, &quality);
         start = 1;
-        prev_quality = quality;
       }
     }
   }
@@ -15855,7 +15855,7 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
    "     @param n_iterations: the number of iterations to iterate the Leiden\n"
    "       algorithm. Each iteration may improve the partition further.\n"
    "     @return: the community membership vector.\n"
-  },  
+  },
   {"community_walktrap",
    (PyCFunction) igraphmodule_Graph_community_walktrap,
    METH_VARARGS | METH_KEYWORDS,

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -1422,27 +1422,30 @@ class Graph(GraphBase):
     def community_leiden(self, objective_function="CPM", weights=None,
         resolution_parameter=1.0, beta=0.01, initial_membership=None,
         n_iterations=2, node_weights=None):
-        """community_leiden(objective_function=CPM, weights=None, 
+        """community_leiden(objective_function=CPM, weights=None,
         resolution_parameter=1.0, beta=0.01, initial_membership=None,
         n_iterations=2, node_weights=None)
 
         Finds the community structure of the graph using the
         Leiden algorithm of Traag, van Eck & Waltman.
 
-        @keyword objective_function: whether to use the Constant Potts 
+        @keyword objective_function: whether to use the Constant Potts
           Model (CPM) or modularity. Must be either C{"CPM"} or C{"modularity"}.
         @keyword weights: edge weights to be used. Can be a sequence or
           iterable or even an edge attribute name.
         @keyword resolution_parameter: the resolution parameter to use.
-          Higher resolutions lead to more smaller communities, while 
+          Higher resolutions lead to more smaller communities, while
           lower resolutions lead to fewer larger communities.
-        @keyword beta: parameter affecting the randomness in the Leiden 
+        @keyword beta: parameter affecting the randomness in the Leiden
           algorithm. This affects only the refinement step of the algorithm.
         @keyword initial_membership: if provided, the Leiden algorithm
           will try to improve this provided membership. If no argument is
           provided, the aglorithm simply starts from the singleton partition.
         @keyword n_iterations: the number of iterations to iterate the Leiden
-          algorithm. Each iteration may improve the partition further.
+          algorithm. Each iteration may improve the partition further. Using
+          a negative number of iterations will run until a stable iteration is
+          encountered (i.e. the quality was not increased during that
+          iteration).
         @keyword node_weights: the node weights used in the Leiden algorithm.
           If this is not provided, it will be automatically determined on the
           basis of whether you want to use CPM or modularity. If you do provide
@@ -1451,14 +1454,14 @@ class Graph(GraphBase):
 
         @newfield ref: Reference
         @ref: Traag, V. A., Waltman, L., & van Eck, N. J. (2019). From Louvain
-          to Leiden: guaranteeing well-connected communities. Scientific 
+          to Leiden: guaranteeing well-connected communities. Scientific
           reports, 9(1), 5233. doi: 10.1038/s41598-019-41695-z
         """
         if objective_function.lower() not in ("cpm", "modularity"):
           raise ValueError("objective_function must be \"CPM\" or \"modularity\".")
 
         membership = GraphBase.community_leiden(self,
-          edge_weights=weights, node_weights=node_weights, 
+          edge_weights=weights, node_weights=node_weights,
           resolution_parameter=resolution_parameter,
           normalize_resolution=(objective_function == "modularity"),
           beta=beta, initial_membership=initial_membership, n_iterations=n_iterations)
@@ -3992,7 +3995,7 @@ class EdgeSeq(_igraph.EdgeSeq):
         # TODO(ntamas): some keyword arguments should be prioritized over
         # others; for instance, we have optimized code paths for _source and
         # _target in directed and undirected graphs if es.is_all() is True;
-        # these should be executed first. This matters only if there are 
+        # these should be executed first. This matters only if there are
         # multiple keyword arguments and es.is_all() is True.
 
         for keyword, value in kwds.iteritems():


### PR DESCRIPTION
The implementation of using a negative number of iterations was not yet correct. The idea of using a negative number of iterations is to continue to run the algorithm until an iteration is stable (i.e. the quality is not increased in that iteration). This was also not yet documented. This PR both documents this behaviour and corrects the implementation.