### PR TITLE
Union/intersection of graphs with vertex names

### DIFF
--- a/src/_igraph/convert.c
+++ b/src/_igraph/convert.c
@@ -2347,6 +2347,41 @@ int igraphmodule_append_PyIter_of_graphs_to_vector_ptr_t(PyObject *it,
 
 /**
  * \ingroup python_interface_conversion
+ * \brief Appends the contents of a Python iterator returning graphs to
+ * an \c igraph_vectorptr_t, and also stores the class of the first graph
+ *
+ * The incoming \c igraph_vector_ptr_t should be INITIALIZED.
+ * Raises suitable Python exceptions when needed.
+ *
+ * \param it the Python iterator
+ * \param v the \c igraph_vector_ptr_t which will contain the result
+ * \return 0 if everything was OK, 1 otherwise
+ */
+int igraphmodule_append_PyIter_of_graphs_to_vector_ptr_t_with_type(PyObject *it,
+    igraph_vector_ptr_t *v,
+    PyTypeObject **g_type) {
+  PyObject *t;
+  int first = 1;
+
+  while ((t=PyIter_Next(it))) {
+    if (!PyObject_TypeCheck(t, &igraphmodule_GraphType)) {
+      PyErr_SetString(PyExc_TypeError, "iterable argument must contain graphs");
+      Py_DECREF(t);
+      return 1;
+    }
+    if (first) {
+      *g_type = Py_TYPE(t);
+      first = 0;
+    }
+    igraph_vector_ptr_push_back(v, &((igraphmodule_GraphObject*)t)->g);
+    Py_DECREF(t);
+  }
+
+  return 0;
+}
+
+/**
+ * \ingroup python_interface_conversion
  * \brief Tries to interpret a Python object as a single vertex ID
  *
  * \param o      the Python object

--- a/src/_igraph/convert.h
+++ b/src/_igraph/convert.h
@@ -100,6 +100,8 @@ PyObject* igraphmodule_strvector_t_to_PyList(igraph_strvector_t *v);
 int igraphmodule_PyList_to_strvector_t(PyObject* v, igraph_strvector_t *result);
 int igraphmodule_append_PyIter_of_graphs_to_vector_ptr_t(PyObject *it,
 		igraph_vector_ptr_t *v);
+int igraphmodule_append_PyIter_of_graphs_to_vector_ptr_t_with_type(PyObject *it,
+		igraph_vector_ptr_t *v, PyTypeObject **g_type);
 int igraphmodule_PyObject_to_vid(PyObject *o, igraph_integer_t *vid, igraph_t *graph);
 int igraphmodule_PyObject_to_vs_t(PyObject *o, igraph_vs_t *vs,
                   igraph_t *graph, igraph_bool_t *return_single,

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -9562,13 +9562,13 @@ PyObject *igraphmodule_Graph_disjoint_union(igraphmodule_GraphObject * self,
  * \brief Creates the union of two or more graphs
  */
 PyObject *igraphmodule_Graph_union(igraphmodule_GraphObject * self,
-                                   PyObject * args, PyObject * kwds,
-                                   )
+                                   PyObject * args, PyObject * kwds)
 {
   static char* kwlist[] = { "edgemaps", NULL };
   PyObject *it, *other;
   PyObject *with_edgemaps = Py_False;
-  igraphmodule_GraphObject *o, *result;
+  igraphmodule_GraphObject *o;
+  PyObject *result;
   igraph_t g;
 
   if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O", kwlist, &other, &with_edgemaps))
@@ -9599,7 +9599,8 @@ PyObject *igraphmodule_Graph_union(igraphmodule_GraphObject * self,
     /* prepare edgemaps if requested */
     if (PyObject_IsTrue(with_edgemaps)) {
       if (igraph_vector_ptr_init(edgemaps, 0)) {
-      return igraphmodule_handle_igraph_error();
+        return igraphmodule_handle_igraph_error();
+      }
     }
 
     /* Create union */
@@ -9622,7 +9623,7 @@ PyObject *igraphmodule_Graph_union(igraphmodule_GraphObject * self,
       Py_INCREF(str_edgemaps);
       for (i = 0; i < no_of_graphs; i++) {
         long int j;
-        long int no_of_edges = (long int) igraph_ecount(VECTOR(*gs)[i]);
+        long int no_of_edges = (long int) igraph_ecount(VECTOR(gs)[i]);
         PyObject *emi = PyList_New((Py_ssize_t) no_of_edges);
         Py_INCREF(emi);
         for (j = 0; j < no_of_edges; j++) {
@@ -9639,14 +9640,15 @@ PyObject *igraphmodule_Graph_union(igraphmodule_GraphObject * self,
       /* wrap in a dictionary */
       result = PyDict_New();
       Py_INCREF(result);
-      PyDict_SetItem(result, str_graph, o);
+      PyDict_SetItem(result, str_graph, (PyObject *) o);
       PyDict_SetItem(result, str_edgemaps, em_list);
 
       igraph_vector_ptr_destroy(edgemaps);
 
     }
     else {
-      CREATE_GRAPH(result, g);
+      CREATE_GRAPH(o, g);
+      result = (PyObject *) o;
     }
   }
   /* Did we receive only two graphs? */
@@ -9667,7 +9669,8 @@ PyObject *igraphmodule_Graph_union(igraphmodule_GraphObject * self,
     /* this is correct as long as attributes are not copied by the
      * operator. if they are copied, the initialization should not empty
      * the attribute hashes */
-    CREATE_GRAPH(result, g);
+    CREATE_GRAPH(o, g);
+    result = (PyObject *) o;
   }
 
   return (PyObject *) result;
@@ -9677,13 +9680,13 @@ PyObject *igraphmodule_Graph_union(igraphmodule_GraphObject * self,
  * \brief Creates the intersection of two or more graphs
  */
 PyObject *igraphmodule_Graph_intersection(igraphmodule_GraphObject * self,
-                                   PyObject * args, PyObject * kwds,
-                                   )
+                                   PyObject * args, PyObject * kwds)
 {
   static char* kwlist[] = { "edgemaps", NULL };
-  PyObject *it;
+  PyObject *it, *other;
   PyObject *with_edgemaps = Py_False;
-  igraphmodule_GraphObject *o, *result;
+  igraphmodule_GraphObject *o;
+  PyObject *result;
   igraph_t g;
 
   if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O", kwlist, &other, &with_edgemaps))
@@ -9714,7 +9717,8 @@ PyObject *igraphmodule_Graph_intersection(igraphmodule_GraphObject * self,
     /* prepare edgemaps if requested */
     if (PyObject_IsTrue(with_edgemaps)) {
       if (igraph_vector_ptr_init(edgemaps, 0)) {
-      return igraphmodule_handle_igraph_error();
+        return igraphmodule_handle_igraph_error();
+      }
     }
 
     /* Create intersection */
@@ -9737,7 +9741,7 @@ PyObject *igraphmodule_Graph_intersection(igraphmodule_GraphObject * self,
       Py_INCREF(str_edgemaps);
       for (i = 0; i < no_of_graphs; i++) {
         long int j;
-        long int no_of_edges = (long int) igraph_ecount(VECTOR(*gs)[i]);
+        long int no_of_edges = (long int) igraph_ecount(VECTOR(gs)[i]);
         PyObject *emi = PyList_New((Py_ssize_t) no_of_edges);
         Py_INCREF(emi);
         for (j = 0; j < no_of_edges; j++) {
@@ -9754,13 +9758,14 @@ PyObject *igraphmodule_Graph_intersection(igraphmodule_GraphObject * self,
       /* wrap in a dictionary */
       result = PyDict_New();
       Py_INCREF(result);
-      PyDict_SetItem(result, str_graph, o);
+      PyDict_SetItem(result, str_graph, (PyObject *) o);
       PyDict_SetItem(result, str_edgemaps, em_list);
 
       igraph_vector_ptr_destroy(edgemaps);
     }
     else {
-      CREATE_GRAPH(result, g);
+      CREATE_GRAPH(o, g);
+      result = (PyObject *) o;
     }
   }
   /* Did we receive only two graphs? */
@@ -9781,7 +9786,8 @@ PyObject *igraphmodule_Graph_intersection(igraphmodule_GraphObject * self,
     /* this is correct as long as attributes are not copied by the
      * operator. if they are copied, the initialization should not empty
      * the attribute hashes */
-    CREATE_GRAPH(result, g);
+    CREATE_GRAPH(o, g);
+    result = (PyObject *) o;
   }
 
   return (PyObject *) result;

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -267,7 +267,8 @@ int igraphmodule_Graph_init(igraphmodule_GraphObject * self,
  *
  * The newly created instance (which will be a subtype of )\c igraph.Graph)
  * will take ownership of the given \c igraph_t. This function is not
- * accessible from Python.
+ * accessible from Python, however it is in the header file for other C API
+ * functions to use.
  */
 PyObject* igraphmodule_Graph_subclass_from_igraph_t(
   PyTypeObject* type, igraph_t *graph

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -9496,70 +9496,9 @@ PyObject *igraphmodule_Graph_edge_attributes(igraphmodule_GraphObject * self)
 }
 
 /**********************************************************************
- * Graph operations (disjoint union, etc)                             *
- * Union and intersection are in operators.c                          *
+ * Graph operations                             *
+ * Disjoint union, union and intersection are in operators.c          *
  **********************************************************************/
-
-/** \ingroup python_interface_graph
- * \brief Creates the disjoint union of two graphs (operator version)
- */
-PyObject *igraphmodule_Graph_disjoint_union(igraphmodule_GraphObject * self,
-                                            PyObject * other)
-{
-  PyObject *it;
-  igraphmodule_GraphObject *o, *result;
-  igraph_t g;
-
-  /* Did we receive an iterable? */
-  it = PyObject_GetIter(other);
-  if (it) {
-    /* Get all elements, store the graphs in an igraph_vector_ptr */
-    igraph_vector_ptr_t gs;
-    if (igraph_vector_ptr_init(&gs, 0)) {
-      Py_DECREF(it);
-      return igraphmodule_handle_igraph_error();
-    }
-    if (igraph_vector_ptr_push_back(&gs, &self->g)) {
-      Py_DECREF(it);
-      igraph_vector_ptr_destroy(&gs);
-      return igraphmodule_handle_igraph_error();
-    }
-    if (igraphmodule_append_PyIter_of_graphs_to_vector_ptr_t(it, &gs)) {
-      igraph_vector_ptr_destroy(&gs);
-      Py_DECREF(it);
-      return NULL;
-    }
-    Py_DECREF(it);
-
-    /* Create disjoint union */
-    if (igraph_disjoint_union_many(&g, &gs)) {
-      igraph_vector_ptr_destroy(&gs);
-      return igraphmodule_handle_igraph_error();
-    }
-
-    igraph_vector_ptr_destroy(&gs);
-  } else {
-    PyErr_Clear();
-    if (!PyObject_TypeCheck(other, &igraphmodule_GraphType)) {
-      Py_INCREF(Py_NotImplemented);
-      return Py_NotImplemented;
-    }
-    o = (igraphmodule_GraphObject *) other;
-
-    if (igraph_disjoint_union(&g, &self->g, &o->g)) {
-      igraphmodule_handle_igraph_error();
-      return NULL;
-    }
-  }
-
-  /* this is correct as long as attributes are not copied by the
-   * operator. if they are copied, the initialization should not empty
-   * the attribute hashes */
-  CREATE_GRAPH(result, g);
-
-  return (PyObject *) result;
-}
-
 
 /** \ingroup python_interface_graph
  * \brief Creates the difference of two graphs (operator version)
@@ -15120,11 +15059,6 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
   {"difference", (PyCFunction) igraphmodule_Graph_difference,
    METH_O,
    "difference(other)\n\nSubtracts the given graph from the original"},
-  {"disjoint_union", (PyCFunction) igraphmodule_Graph_disjoint_union,
-   METH_O,
-   "disjoint_union(graphs)\n\n"
-   "Creates the disjoint union of two (or more) graphs.\n\n"
-   "@param graphs: the list of graphs to be united with the current one.\n"},
 
   /**********************/
   /* DOMINATORS         */

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -9496,7 +9496,8 @@ PyObject *igraphmodule_Graph_edge_attributes(igraphmodule_GraphObject * self)
 }
 
 /**********************************************************************
- * Graph operations (union, intersection etc)                         *
+ * Graph operations (disjoint union, etc)                             *
+ * Union and intersection are in operators.c                          *
  **********************************************************************/
 
 /** \ingroup python_interface_graph
@@ -9559,131 +9560,6 @@ PyObject *igraphmodule_Graph_disjoint_union(igraphmodule_GraphObject * self,
   return (PyObject *) result;
 }
 
-/** \ingroup python_interface_graph
- * \brief Creates the union of two graphs (operator version)
- */
-PyObject *igraphmodule_Graph_union(igraphmodule_GraphObject * self,
-                                   PyObject * other)
-{
-  PyObject *it;
-  igraphmodule_GraphObject *o, *result;
-  igraph_t g;
-
-  /* Did we receive an iterable? */
-  it = PyObject_GetIter(other);
-  if (it) {
-    /* Get all elements, store the graphs in an igraph_vector_ptr */
-    igraph_vector_ptr_t gs;
-    if (igraph_vector_ptr_init(&gs, 0)) {
-      Py_DECREF(it);
-      return igraphmodule_handle_igraph_error();
-    }
-    if (igraph_vector_ptr_push_back(&gs, &self->g)) {
-      Py_DECREF(it);
-      igraph_vector_ptr_destroy(&gs);
-      return igraphmodule_handle_igraph_error();
-    }
-    if (igraphmodule_append_PyIter_of_graphs_to_vector_ptr_t(it, &gs)) {
-      Py_DECREF(it);
-      igraph_vector_ptr_destroy(&gs);
-      return NULL;
-    }
-    Py_DECREF(it);
-
-    /* Create union */
-    if (igraph_union_many(&g, &gs, /*edgemaps=*/ 0)) {
-      igraph_vector_ptr_destroy(&gs);
-      igraphmodule_handle_igraph_error();
-      return NULL;
-    }
-
-    igraph_vector_ptr_destroy(&gs);
-  }
-  else {
-    PyErr_Clear();
-    if (!PyObject_TypeCheck(other, &igraphmodule_GraphType)) {
-      Py_INCREF(Py_NotImplemented);
-      return Py_NotImplemented;
-    }
-    o = (igraphmodule_GraphObject *) other;
-
-    if (igraph_union(&g, &self->g, &o->g, /*edge_map1=*/ 0,
-		     /*edge_map2=*/ 0)) {
-      igraphmodule_handle_igraph_error();
-      return NULL;
-    }
-  }
-
-  /* this is correct as long as attributes are not copied by the
-   * operator. if they are copied, the initialization should not empty
-   * the attribute hashes */
-  CREATE_GRAPH(result, g);
-
-  return (PyObject *) result;
-}
-
-/** \ingroup python_interface_graph
- * \brief Creates the intersection of two graphs (operator version)
- */
-PyObject *igraphmodule_Graph_intersection(igraphmodule_GraphObject * self,
-                                          PyObject * other)
-{
-  PyObject *it;
-  igraphmodule_GraphObject *o, *result;
-  igraph_t g;
-
-  /* Did we receive an iterable? */
-  it = PyObject_GetIter(other);
-  if (it) {
-    /* Get all elements, store the graphs in an igraph_vector_ptr */
-    igraph_vector_ptr_t gs;
-    if (igraph_vector_ptr_init(&gs, 0)) {
-      Py_DECREF(it);
-      return igraphmodule_handle_igraph_error();
-    }
-    if (igraph_vector_ptr_push_back(&gs, &self->g)) {
-      Py_DECREF(it);
-      igraph_vector_ptr_destroy(&gs);
-      return igraphmodule_handle_igraph_error();
-    }
-    if (igraphmodule_append_PyIter_of_graphs_to_vector_ptr_t(it, &gs)) {
-      Py_DECREF(it);
-      igraph_vector_ptr_destroy(&gs);
-      return NULL;
-    }
-    Py_DECREF(it);
-
-    /* Create union */
-    if (igraph_intersection_many(&g, &gs, /*edgemaps=*/ 0)) {
-      igraph_vector_ptr_destroy(&gs);
-      igraphmodule_handle_igraph_error();
-      return NULL;
-    }
-
-    igraph_vector_ptr_destroy(&gs);
-  }
-  else {
-    PyErr_Clear();
-    if (!PyObject_TypeCheck(other, &igraphmodule_GraphType)) {
-      Py_INCREF(Py_NotImplemented);
-      return Py_NotImplemented;
-    }
-    o = (igraphmodule_GraphObject *) other;
-
-    if (igraph_intersection(&g, &self->g, &o->g, /*edge_map1=*/ 0,
-			    /*edge_map2=*/ 0)) {
-      igraphmodule_handle_igraph_error();
-      return NULL;
-    }
-  }
-
-  /* this is correct as long as attributes are not copied by the
-   * operator. if they are copied, the initialization should not empty
-   * the attribute hashes */
-  CREATE_GRAPH(result, g);
-
-  return (PyObject *) result;
-}
 
 /** \ingroup python_interface_graph
  * \brief Creates the difference of two graphs (operator version)
@@ -15249,18 +15125,6 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
    "disjoint_union(graphs)\n\n"
    "Creates the disjoint union of two (or more) graphs.\n\n"
    "@param graphs: the list of graphs to be united with the current one.\n"},
-  {"intersection", (PyCFunction) igraphmodule_Graph_intersection,
-   METH_O,
-   "intersection(graphs)\n\n"
-   "Creates the intersection of two (or more) graphs.\n\n"
-   "@param graphs: the list of graphs to be intersected with\n"
-   "  the current one.\n"},
-  {"union", (PyCFunction) igraphmodule_Graph_union,
-   METH_O,
-   "union(graphs)\n\n"
-   "Creates the union of two (or more) graphs.\n\n"
-   "@param graphs: the list of graphs to be united with\n"
-   "  the current one.\n"},
 
   /**********************/
   /* DOMINATORS         */
@@ -15998,9 +15862,9 @@ PyNumberMethods igraphmodule_Graph_as_number = {
   (unaryfunc) igraphmodule_Graph_complementer_op, /*nb_invert */
   0,                            /*nb_lshift */
   0,                            /*nb_rshift */
-  (binaryfunc) igraphmodule_Graph_intersection, /*nb_and */
+  0,                            /*nb_and */
   0,                            /*nb_xor */
-  (binaryfunc) igraphmodule_Graph_union,  /*nb_or */
+  0,                            /*nb_or */
 #ifndef IGRAPH_PYTHON3
   0,                            /*nb_coerce */
 #endif

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -9564,7 +9564,7 @@ PyObject *igraphmodule_Graph_disjoint_union(igraphmodule_GraphObject * self,
 PyObject *igraphmodule_Graph_union(igraphmodule_GraphObject * self,
                                    PyObject * args, PyObject * kwds)
 {
-  static char* kwlist[] = { "edgemaps", NULL };
+  static char* kwlist[] = { "other", "edgemaps", NULL };
   PyObject *it, *other;
   PyObject *with_edgemaps = Py_False;
   igraphmodule_GraphObject *o;
@@ -9682,7 +9682,7 @@ PyObject *igraphmodule_Graph_union(igraphmodule_GraphObject * self,
 PyObject *igraphmodule_Graph_intersection(igraphmodule_GraphObject * self,
                                    PyObject * args, PyObject * kwds)
 {
-  static char* kwlist[] = { "edgemaps", NULL };
+  static char* kwlist[] = { "other", "edgemaps", NULL };
   PyObject *it, *other;
   PyObject *with_edgemaps = Py_False;
   igraphmodule_GraphObject *o;

--- a/src/_igraph/graphobject.h
+++ b/src/_igraph/graphobject.h
@@ -55,6 +55,7 @@ int igraphmodule_Graph_clear(igraphmodule_GraphObject *self);
 int igraphmodule_Graph_traverse(igraphmodule_GraphObject *self, visitproc visit, void *arg);
 void igraphmodule_Graph_dealloc(igraphmodule_GraphObject* self);
 int igraphmodule_Graph_init(igraphmodule_GraphObject *self, PyObject *args, PyObject *kwds);
+PyObject* igraphmodule_Graph_subclass_from_igraph_t(PyTypeObject* type, igraph_t *graph);
 PyObject* igraphmodule_Graph_from_igraph_t(igraph_t *graph);
 PyObject* igraphmodule_Graph_str(igraphmodule_GraphObject *self);
 

--- a/src/_igraph/graphobject.h
+++ b/src/_igraph/graphobject.h
@@ -191,8 +191,8 @@ PyObject* igraphmodule_Graph_complementer_op(igraphmodule_GraphObject* self);
 PyObject* igraphmodule_Graph_compose(igraphmodule_GraphObject* self, PyObject* other);
 PyObject* igraphmodule_Graph_difference(igraphmodule_GraphObject* self, PyObject* other);
 PyObject* igraphmodule_Graph_disjoint_union(igraphmodule_GraphObject* self, PyObject* other);
-PyObject* igraphmodule_Graph_intersection(igraphmodule_GraphObject* self, PyObject* args, PyObject* kwds);
-PyObject* igraphmodule_Graph_union(igraphmodule_GraphObject* self, PyObject* args, PyObject* kwds);
+PyObject* igraphmodule_Graph_intersection(igraphmodule_GraphObject* self, PyObject* other);
+PyObject* igraphmodule_Graph_union(igraphmodule_GraphObject* self, PyObject* other);
 
 PyObject* igraphmodule_Graph_bfs(igraphmodule_GraphObject* self, PyObject* args, PyObject* kwds);
 PyObject* igraphmodule_Graph_bfsiter(igraphmodule_GraphObject* self, PyObject* args, PyObject* kwds);

--- a/src/_igraph/graphobject.h
+++ b/src/_igraph/graphobject.h
@@ -192,7 +192,7 @@ PyObject* igraphmodule_Graph_compose(igraphmodule_GraphObject* self, PyObject* o
 PyObject* igraphmodule_Graph_difference(igraphmodule_GraphObject* self, PyObject* other);
 PyObject* igraphmodule_Graph_disjoint_union(igraphmodule_GraphObject* self, PyObject* other);
 PyObject* igraphmodule_Graph_intersection(igraphmodule_GraphObject* self, PyObject* other);
-PyObject* igraphmodule_Graph_union(igraphmodule_GraphObject* self, PyObject* other);
+PyObject* igraphmodule_Graph_union(igraphmodule_GraphObject* self, PyObject* args, PyObject * kwds);
 
 PyObject* igraphmodule_Graph_bfs(igraphmodule_GraphObject* self, PyObject* args, PyObject* kwds);
 PyObject* igraphmodule_Graph_bfsiter(igraphmodule_GraphObject* self, PyObject* args, PyObject* kwds);

--- a/src/_igraph/graphobject.h
+++ b/src/_igraph/graphobject.h
@@ -192,8 +192,6 @@ PyObject* igraphmodule_Graph_complementer_op(igraphmodule_GraphObject* self);
 PyObject* igraphmodule_Graph_compose(igraphmodule_GraphObject* self, PyObject* other);
 PyObject* igraphmodule_Graph_difference(igraphmodule_GraphObject* self, PyObject* other);
 PyObject* igraphmodule_Graph_disjoint_union(igraphmodule_GraphObject* self, PyObject* other);
-PyObject* igraphmodule_Graph_intersection(igraphmodule_GraphObject* self, PyObject* other);
-PyObject* igraphmodule_Graph_union(igraphmodule_GraphObject* self, PyObject* other);
 
 PyObject* igraphmodule_Graph_bfs(igraphmodule_GraphObject* self, PyObject* args, PyObject* kwds);
 PyObject* igraphmodule_Graph_bfsiter(igraphmodule_GraphObject* self, PyObject* args, PyObject* kwds);

--- a/src/_igraph/graphobject.h
+++ b/src/_igraph/graphobject.h
@@ -191,8 +191,8 @@ PyObject* igraphmodule_Graph_complementer_op(igraphmodule_GraphObject* self);
 PyObject* igraphmodule_Graph_compose(igraphmodule_GraphObject* self, PyObject* other);
 PyObject* igraphmodule_Graph_difference(igraphmodule_GraphObject* self, PyObject* other);
 PyObject* igraphmodule_Graph_disjoint_union(igraphmodule_GraphObject* self, PyObject* other);
-PyObject* igraphmodule_Graph_intersection(igraphmodule_GraphObject* self, PyObject* other);
-PyObject* igraphmodule_Graph_union(igraphmodule_GraphObject* self, PyObject* args, PyObject * kwds);
+PyObject* igraphmodule_Graph_intersection(igraphmodule_GraphObject* self, PyObject* args, PyObject* kwds);
+PyObject* igraphmodule_Graph_union(igraphmodule_GraphObject* self, PyObject* args, PyObject* kwds);
 
 PyObject* igraphmodule_Graph_bfs(igraphmodule_GraphObject* self, PyObject* args, PyObject* kwds);
 PyObject* igraphmodule_Graph_bfsiter(igraphmodule_GraphObject* self, PyObject* args, PyObject* kwds);

--- a/src/_igraph/igraphmodule.c
+++ b/src/_igraph/igraphmodule.c
@@ -36,6 +36,7 @@
 #include "random.h"
 #include "vertexobject.h"
 #include "vertexseqobject.h"
+#include "operators.h"
 
 #define IGRAPH_MODULE
 #include "igraphmodule_api.h"
@@ -650,6 +651,14 @@ static PyMethodDef igraphmodule_methods[] =
     METH_VARARGS | METH_KEYWORDS,
     "_split_join_distance(comm1, comm2)"
   },
+  {"_union", (PyCFunction)igraphmodule__union,
+    METH_VARARGS | METH_KEYWORDS,
+    "_union(graphs, edgemaps)"
+  },
+  {"_intersection", (PyCFunction)igraphmodule__intersection,
+    METH_VARARGS | METH_KEYWORDS,
+    "_intersection(graphs, edgemaps)"
+  },
   {NULL, NULL, 0, NULL}
 };
 
@@ -657,7 +666,7 @@ static PyMethodDef igraphmodule_methods[] =
   "Low-level Python interface for the igraph library. " \
   "Should not be used directly.\n\n"                    \
   "@undocumented: community_to_membership, _compare_communities, _power_law_fit, " \
-  "_split_join_distance"
+  "_split_join_distance, _union, _intersection"
 
 /**
  * Module definition table (only for Python 3.x)

--- a/src/_igraph/igraphmodule.c
+++ b/src/_igraph/igraphmodule.c
@@ -670,7 +670,7 @@ static PyMethodDef igraphmodule_methods[] =
   "Low-level Python interface for the igraph library. " \
   "Should not be used directly.\n\n"                    \
   "@undocumented: community_to_membership, _compare_communities, _power_law_fit, " \
-  "_split_join_distance, _union, _intersection"
+  "_split_join_distance, _union, _intersection, _disjoint_union"
 
 /**
  * Module definition table (only for Python 3.x)

--- a/src/_igraph/igraphmodule.c
+++ b/src/_igraph/igraphmodule.c
@@ -651,6 +651,10 @@ static PyMethodDef igraphmodule_methods[] =
     METH_VARARGS | METH_KEYWORDS,
     "_split_join_distance(comm1, comm2)"
   },
+  {"_disjoint_union", (PyCFunction)igraphmodule__disjoint_union,
+    METH_VARARGS | METH_KEYWORDS,
+    "_disjoint_union(graphs)"
+  },
   {"_union", (PyCFunction)igraphmodule__union,
     METH_VARARGS | METH_KEYWORDS,
     "_union(graphs, edgemaps)"

--- a/src/_igraph/operators.c
+++ b/src/_igraph/operators.c
@@ -35,6 +35,7 @@ PyObject *igraphmodule__disjoint_union(PyObject *self,
   static char* kwlist[] = { "graphs", NULL };
   PyObject *it, *graphs;
   long int no_of_graphs;
+  igraph_vector_ptr_t gs;
   igraphmodule_GraphObject *o;
   PyObject *result;
   PyTypeObject *result_type;
@@ -52,7 +53,6 @@ PyObject *igraphmodule__disjoint_union(PyObject *self,
   }
 
   /* Get all elements, store the graphs in an igraph_vector_ptr */
-  igraph_vector_ptr_t gs;
   if (igraph_vector_ptr_init(&gs, 0)) {
     Py_DECREF(it);
     return igraphmodule_handle_igraph_error();
@@ -100,6 +100,7 @@ PyObject *igraphmodule__union(PyObject *self,
   PyObject *it, *em_list, *graphs, *with_edgemaps_o;
   int with_edgemaps = 0;
   long int no_of_graphs;
+  igraph_vector_ptr_t gs;
   igraphmodule_GraphObject *o;
   PyObject *result;
   PyTypeObject *result_type;
@@ -120,7 +121,6 @@ PyObject *igraphmodule__union(PyObject *self,
   }
 
   /* Get all elements, store the graphs in an igraph_vector_ptr */
-  igraph_vector_ptr_t gs;
   if (igraph_vector_ptr_init(&gs, 0)) {
     Py_DECREF(it);
     return igraphmodule_handle_igraph_error();
@@ -158,9 +158,9 @@ PyObject *igraphmodule__union(PyObject *self,
       PyObject *emi = PyList_New((Py_ssize_t) no_of_edges);
       for (j = 0; j < no_of_edges; j++) {
         PyObject *dest = PyLong_FromLong(VECTOR(*map)[j]);
-        PyList_SetItem(emi, (Py_ssize_t) j, dest);
+        PyList_SET_ITEM(emi, (Py_ssize_t) j, dest);
       }
-      PyList_SetItem(em_list, (Py_ssize_t) i, emi);
+      PyList_SET_ITEM(em_list, (Py_ssize_t) i, emi);
     }
     igraph_vector_ptr_destroy(&edgemaps);
   }
@@ -189,11 +189,10 @@ PyObject *igraphmodule__union(PyObject *self,
 
   if (with_edgemaps) {
     /* wrap in a dictionary */
-    PyObject * str_graph = PyUnicode_FromString("graph");
-    PyObject * str_edgemaps = PyUnicode_FromString("edgemaps");
     result = PyDict_New();
-    PyDict_SetItem(result, str_graph, (PyObject *) o);
-    PyDict_SetItem(result, str_edgemaps, em_list);
+    PyDict_SetItemString(result, "graph", (PyObject *) o);
+    Py_DECREF(o);
+    PyDict_SetItemString(result, "edgemaps", em_list);
   }
   else {
     result = (PyObject *) o;
@@ -212,6 +211,7 @@ PyObject *igraphmodule__intersection(PyObject *self,
   PyObject *it, *em_list, *graphs, *with_edgemaps_o;
   int with_edgemaps = 0;
   long int no_of_graphs;
+  igraph_vector_ptr_t gs;
   igraphmodule_GraphObject *o;
   PyObject *result;
   PyTypeObject *result_type;
@@ -232,7 +232,6 @@ PyObject *igraphmodule__intersection(PyObject *self,
   }
 
   /* Get all elements, store the graphs in an igraph_vector_ptr */
-  igraph_vector_ptr_t gs;
   if (igraph_vector_ptr_init(&gs, 0)) {
     Py_DECREF(it);
     return igraphmodule_handle_igraph_error();
@@ -269,9 +268,9 @@ PyObject *igraphmodule__intersection(PyObject *self,
       PyObject *emi = PyList_New((Py_ssize_t) no_of_edges);
       for (j = 0; j < no_of_edges; j++) {
         PyObject *dest = PyLong_FromLong(VECTOR(*map)[j]);
-        PyList_SetItem(emi, (Py_ssize_t) j, dest);
+        PyList_SET_ITEM(emi, (Py_ssize_t) j, dest);
       }
-      PyList_SetItem(em_list, (Py_ssize_t) i, emi);
+      PyList_SET_ITEM(em_list, (Py_ssize_t) i, emi);
     }
     igraph_vector_ptr_destroy(&edgemaps);
 
@@ -301,11 +300,11 @@ PyObject *igraphmodule__intersection(PyObject *self,
 
   if (with_edgemaps) {
     /* wrap in a dictionary */
-    PyObject * str_graph = PyUnicode_FromString("graph");
-    PyObject * str_edgemaps = PyUnicode_FromString("edgemaps");
     result = PyDict_New();
-    PyDict_SetItem(result, str_graph, (PyObject *) o);
-    PyDict_SetItem(result, str_edgemaps, em_list);
+    PyDict_SetItemString(result, "graph", (PyObject *) o);
+    Py_DECREF(o);
+    PyDict_SetItemString(result, "edgemaps", em_list);
+    Py_DECREF(em_list);
   }
   else {
     result = (PyObject *) o;

--- a/src/_igraph/operators.c
+++ b/src/_igraph/operators.c
@@ -35,8 +35,10 @@ PyObject *igraphmodule__union(PyObject *self,
   static char* kwlist[] = { "graphs", "edgemaps", NULL };
   PyObject *it, *em_list, *graphs, *with_edgemaps_o;
   int with_edgemaps = 0;
+  long int no_of_graphs;
   igraphmodule_GraphObject *o;
   PyObject *result;
+  PyTypeObject *result_type;
   igraph_t g;
 
   if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O", kwlist,
@@ -60,12 +62,13 @@ PyObject *igraphmodule__union(PyObject *self,
     Py_DECREF(it);
     return igraphmodule_handle_igraph_error();
   }
-  if (igraphmodule_append_PyIter_of_graphs_to_vector_ptr_t(it, &gs)) {
+  if (igraphmodule_append_PyIter_of_graphs_to_vector_ptr_t_with_type(it, &gs, &result_type)) {
     Py_DECREF(it);
     igraph_vector_ptr_destroy(&gs);
     return NULL;
   }
   Py_DECREF(it);
+  no_of_graphs = (long int) igraph_vector_ptr_size(&gs);
 
   /* prepare edgemaps if requested */
   if (with_edgemaps) {
@@ -81,11 +84,8 @@ PyObject *igraphmodule__union(PyObject *self,
     return NULL;
   }
 
-  igraph_vector_ptr_destroy(&gs);
-
   if (with_edgemaps) {
     long int i;
-    long int no_of_graphs = (long int) igraph_vector_ptr_size(&gs);
     em_list = PyList_New((Py_ssize_t) no_of_graphs);
     Py_INCREF(em_list);
     for (i = 0; i < no_of_graphs; i++) {
@@ -102,10 +102,19 @@ PyObject *igraphmodule__union(PyObject *self,
     igraph_vector_ptr_destroy(edgemaps);
   }
 
+  igraph_vector_ptr_destroy(&gs);
+
   /* this is correct as long as attributes are not copied by the
    * operator. if they are copied, the initialization should not empty
    * the attribute hashes */
-  o = (igraphmodule_GraphObject*) igraphmodule_Graph_from_igraph_t(&g);
+  if (no_of_graphs > 0) {
+    o = (igraphmodule_GraphObject*) igraphmodule_Graph_subclass_from_igraph_t(
+        result_type,
+        &g);
+  }
+  else {
+    o = (igraphmodule_GraphObject*) igraphmodule_Graph_from_igraph_t(&g);
+  }
 
   if (with_edgemaps) {
     /* wrap in a dictionary */
@@ -134,8 +143,10 @@ PyObject *igraphmodule__intersection(PyObject *self,
   static char* kwlist[] = { "graphs", "edgemaps", NULL };
   PyObject *it, *em_list, *graphs, *with_edgemaps_o;
   int with_edgemaps = 0;
+  long int no_of_graphs;
   igraphmodule_GraphObject *o;
   PyObject *result;
+  PyTypeObject *result_type;
   igraph_t g;
 
   if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O", kwlist,
@@ -159,12 +170,13 @@ PyObject *igraphmodule__intersection(PyObject *self,
     Py_DECREF(it);
     return igraphmodule_handle_igraph_error();
   }
-  if (igraphmodule_append_PyIter_of_graphs_to_vector_ptr_t(it, &gs)) {
+  if (igraphmodule_append_PyIter_of_graphs_to_vector_ptr_t_with_type(it, &gs, &result_type)) {
     Py_DECREF(it);
     igraph_vector_ptr_destroy(&gs);
     return NULL;
   }
   Py_DECREF(it);
+  no_of_graphs = (long int) igraph_vector_ptr_size(&gs);
 
   /* prepare edgemaps if requested */
   if (with_edgemaps) {
@@ -180,11 +192,8 @@ PyObject *igraphmodule__intersection(PyObject *self,
     return NULL;
   }
 
-  igraph_vector_ptr_destroy(&gs);
-
   if (with_edgemaps) {
     long int i;
-    long int no_of_graphs = (long int) igraph_vector_ptr_size(&gs);
     em_list = PyList_New((Py_ssize_t) no_of_graphs);
     Py_INCREF(em_list);
     for (i = 0; i < no_of_graphs; i++) {
@@ -201,10 +210,19 @@ PyObject *igraphmodule__intersection(PyObject *self,
     igraph_vector_ptr_destroy(edgemaps);
   }
 
+  igraph_vector_ptr_destroy(&gs);
+
   /* this is correct as long as attributes are not copied by the
    * operator. if they are copied, the initialization should not empty
    * the attribute hashes */
-  o = (igraphmodule_GraphObject*) igraphmodule_Graph_from_igraph_t(&g);
+  if (no_of_graphs > 0) {
+    o = (igraphmodule_GraphObject*) igraphmodule_Graph_subclass_from_igraph_t(
+        result_type,
+        &g);
+  }
+  else {
+    o = (igraphmodule_GraphObject*) igraphmodule_Graph_from_igraph_t(&g);
+  }
 
   if (with_edgemaps) {
     /* wrap in a dictionary */

--- a/src/_igraph/operators.c
+++ b/src/_igraph/operators.c
@@ -84,18 +84,17 @@ PyObject *igraphmodule__union(PyObject *self,
       return NULL;
     }
 
-    /* extract edgema[s */
+    /* extract edgemaps */
     long int i;
     em_list = PyList_New((Py_ssize_t) no_of_graphs);
-    Py_INCREF(em_list);
     for (i = 0; i < no_of_graphs; i++) {
       long int j;
       long int no_of_edges = (long int) igraph_ecount(VECTOR(gs)[i]);
+      igraph_vector_t *map = VECTOR(edgemaps)[i];
       PyObject *emi = PyList_New((Py_ssize_t) no_of_edges);
-      Py_INCREF(emi);
       for (j = 0; j < no_of_edges; j++) {
-        igraph_vector_t *map = VECTOR(edgemaps)[j];
-        PyList_SetItem(emi, (Py_ssize_t) j, PyLong_FromLong(VECTOR(*map)[j]));
+        PyObject *dest = PyLong_FromLong(VECTOR(*map)[j]);
+        PyList_SetItem(emi, (Py_ssize_t) j, dest);
       }
       PyList_SetItem(em_list, (Py_ssize_t) i, emi);
     }
@@ -128,10 +127,7 @@ PyObject *igraphmodule__union(PyObject *self,
     /* wrap in a dictionary */
     PyObject * str_graph = PyUnicode_FromString("graph");
     PyObject * str_edgemaps = PyUnicode_FromString("edgemaps");
-    Py_INCREF(str_graph);
-    Py_INCREF(str_edgemaps);
     result = PyDict_New();
-    Py_INCREF(result);
     PyDict_SetItem(result, str_graph, (PyObject *) o);
     PyDict_SetItem(result, str_edgemaps, em_list);
   }
@@ -202,15 +198,14 @@ PyObject *igraphmodule__intersection(PyObject *self,
 
     long int i;
     em_list = PyList_New((Py_ssize_t) no_of_graphs);
-    Py_INCREF(em_list);
     for (i = 0; i < no_of_graphs; i++) {
       long int j;
       long int no_of_edges = (long int) igraph_ecount(VECTOR(gs)[i]);
+      igraph_vector_t *map = VECTOR(edgemaps)[i];
       PyObject *emi = PyList_New((Py_ssize_t) no_of_edges);
-      Py_INCREF(emi);
       for (j = 0; j < no_of_edges; j++) {
-        igraph_vector_t *map = VECTOR(edgemaps)[j];
-        PyList_SetItem(emi, (Py_ssize_t) j, PyLong_FromLong(VECTOR(*map)[j]));
+        PyObject *dest = PyLong_FromLong(VECTOR(*map)[j]);
+        PyList_SetItem(emi, (Py_ssize_t) j, dest);
       }
       PyList_SetItem(em_list, (Py_ssize_t) i, emi);
     }
@@ -244,10 +239,7 @@ PyObject *igraphmodule__intersection(PyObject *self,
     /* wrap in a dictionary */
     PyObject * str_graph = PyUnicode_FromString("graph");
     PyObject * str_edgemaps = PyUnicode_FromString("edgemaps");
-    Py_INCREF(str_graph);
-    Py_INCREF(str_edgemaps);
     result = PyDict_New();
-    Py_INCREF(result);
     PyDict_SetItem(result, str_graph, (PyObject *) o);
     PyDict_SetItem(result, str_edgemaps, em_list);
   }

--- a/src/_igraph/operators.c
+++ b/src/_igraph/operators.c
@@ -29,14 +29,23 @@
 /** \ingroup python_interface_graph
  * \brief Creates the union of two or more graphs
  */
-PyObject *igraphmodule__union(PyObject * graphs, PyObject * with_edgemaps_o)
+PyObject *igraphmodule__union(PyObject *self,
+		PyObject *args, PyObject *kwds)
 {
-  PyObject *it, *em_list;
-  int with_edgemaps = PyObject_IsTrue(with_edgemaps_o);
+  static char* kwlist[] = { "graphs", "edgemaps", NULL };
+  PyObject *it, *em_list, *graphs, *with_edgemaps_o;
+  int with_edgemaps = 0;
   igraphmodule_GraphObject *o;
   PyObject *result;
   igraph_t g;
-  
+
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O", kwlist,
+      &graphs, &with_edgemaps_o))
+    return NULL;
+
+  if (PyObject_IsTrue(with_edgemaps_o))
+    with_edgemaps = 1;
+
   /* Needs to be an iterable */
   it = PyObject_GetIter(graphs);
   if (!it) {
@@ -119,13 +128,22 @@ PyObject *igraphmodule__union(PyObject * graphs, PyObject * with_edgemaps_o)
 /** \ingroup python_interface_graph
  * \brief Creates the intersection of two or more graphs
  */
-PyObject *igraphmodule__intersection(PyObject * graphs, PyObject * with_edgemaps_o)
+PyObject *igraphmodule__intersection(PyObject *self,
+		PyObject *args, PyObject *kwds)
 {
-  PyObject *it, *em_list;
-  int with_edgemaps = PyObject_IsTrue(with_edgemaps_o);
+  static char* kwlist[] = { "graphs", "edgemaps", NULL };
+  PyObject *it, *em_list, *graphs, *with_edgemaps_o;
+  int with_edgemaps = 0;
   igraphmodule_GraphObject *o;
   PyObject *result;
   igraph_t g;
+
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O", kwlist,
+      &graphs, &with_edgemaps_o))
+    return NULL;
+
+  if (PyObject_IsTrue(with_edgemaps_o))
+    with_edgemaps = 1;
 
   /* Needs to be an iterable */
   it = PyObject_GetIter(graphs);

--- a/src/_igraph/operators.c
+++ b/src/_igraph/operators.c
@@ -1,0 +1,209 @@
+/* vim:set ts=4 sw=2 sts=2 et:  */
+/*
+   IGraph library.
+   Copyright (C) 2006-2012  Tamas Nepusz <ntamas@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+
+*/
+
+#include "common.h"
+#include "convert.h"
+#include "error.h"
+#include "graphobject.h"
+
+
+/** \ingroup python_interface_graph
+ * \brief Creates the union of two or more graphs
+ */
+PyObject *igraphmodule__union(PyObject * graphs, PyObject * with_edgemaps_o)
+{
+  PyObject *it, *em_list;
+  int with_edgemaps = PyObject_IsTrue(with_edgemaps_o);
+  igraphmodule_GraphObject *o;
+  PyObject *result;
+  igraph_t g;
+  
+  /* Needs to be an iterable */
+  it = PyObject_GetIter(graphs);
+  if (!it) {
+      Py_DECREF(it);
+      return igraphmodule_handle_igraph_error();
+  }
+
+  igraph_vector_ptr_t *edgemaps = 0;
+  /* Get all elements, store the graphs in an igraph_vector_ptr */
+  igraph_vector_ptr_t gs;
+  if (igraph_vector_ptr_init(&gs, 0)) {
+    Py_DECREF(it);
+    return igraphmodule_handle_igraph_error();
+  }
+  if (igraphmodule_append_PyIter_of_graphs_to_vector_ptr_t(it, &gs)) {
+    Py_DECREF(it);
+    igraph_vector_ptr_destroy(&gs);
+    return NULL;
+  }
+  Py_DECREF(it);
+
+  /* prepare edgemaps if requested */
+  if (with_edgemaps) {
+    if (igraph_vector_ptr_init(edgemaps, 0)) {
+      return igraphmodule_handle_igraph_error();
+    }
+  }
+
+  /* Create union */
+  if (igraph_union_many(&g, &gs, edgemaps)) {
+    igraph_vector_ptr_destroy(&gs);
+    igraphmodule_handle_igraph_error();
+    return NULL;
+  }
+
+  igraph_vector_ptr_destroy(&gs);
+
+  if (with_edgemaps) {
+    long int i;
+    long int no_of_graphs = (long int) igraph_vector_ptr_size(&gs);
+    em_list = PyList_New((Py_ssize_t) no_of_graphs);
+    Py_INCREF(em_list);
+    for (i = 0; i < no_of_graphs; i++) {
+      long int j;
+      long int no_of_edges = (long int) igraph_ecount(VECTOR(gs)[i]);
+      PyObject *emi = PyList_New((Py_ssize_t) no_of_edges);
+      Py_INCREF(emi);
+      for (j = 0; j < no_of_edges; j++) {
+        igraph_vector_t *map = VECTOR(*edgemaps)[j];
+        PyList_SetItem(emi, (Py_ssize_t) j, PyLong_FromLong(VECTOR(*map)[j]));
+      }
+      PyList_SetItem(em_list, (Py_ssize_t) i, emi);
+    }
+    igraph_vector_ptr_destroy(edgemaps);
+  }
+
+  /* this is correct as long as attributes are not copied by the
+   * operator. if they are copied, the initialization should not empty
+   * the attribute hashes */
+  o = (igraphmodule_GraphObject*) igraphmodule_Graph_from_igraph_t(&g);
+
+  if (with_edgemaps) {
+    /* wrap in a dictionary */
+    PyObject * str_graph = PyUnicode_FromString("graph");
+    PyObject * str_edgemaps = PyUnicode_FromString("edgemaps");
+    Py_INCREF(str_graph);
+    Py_INCREF(str_edgemaps);
+    result = PyDict_New();
+    Py_INCREF(result);
+    PyDict_SetItem(result, str_graph, (PyObject *) o);
+    PyDict_SetItem(result, str_edgemaps, em_list);
+  }
+  else {
+    result = (PyObject *) o;
+  }
+
+  return (PyObject *) result;
+}
+
+/** \ingroup python_interface_graph
+ * \brief Creates the intersection of two or more graphs
+ */
+PyObject *igraphmodule__intersection(PyObject * graphs, PyObject * with_edgemaps_o)
+{
+  PyObject *it, *em_list;
+  int with_edgemaps = PyObject_IsTrue(with_edgemaps_o);
+  igraphmodule_GraphObject *o;
+  PyObject *result;
+  igraph_t g;
+
+  /* Needs to be an iterable */
+  it = PyObject_GetIter(graphs);
+  if (!it) {
+      Py_DECREF(it);
+      return igraphmodule_handle_igraph_error();
+  }
+
+  igraph_vector_ptr_t *edgemaps = 0;
+  /* Get all elements, store the graphs in an igraph_vector_ptr */
+  igraph_vector_ptr_t gs;
+  if (igraph_vector_ptr_init(&gs, 0)) {
+    Py_DECREF(it);
+    return igraphmodule_handle_igraph_error();
+  }
+  if (igraphmodule_append_PyIter_of_graphs_to_vector_ptr_t(it, &gs)) {
+    Py_DECREF(it);
+    igraph_vector_ptr_destroy(&gs);
+    return NULL;
+  }
+  Py_DECREF(it);
+
+  /* prepare edgemaps if requested */
+  if (with_edgemaps) {
+    if (igraph_vector_ptr_init(edgemaps, 0)) {
+      return igraphmodule_handle_igraph_error();
+    }
+  }
+
+  /* Create intersection */
+  if (igraph_intersection_many(&g, &gs, edgemaps)) {
+    igraph_vector_ptr_destroy(&gs);
+    igraphmodule_handle_igraph_error();
+    return NULL;
+  }
+
+  igraph_vector_ptr_destroy(&gs);
+
+  if (with_edgemaps) {
+    long int i;
+    long int no_of_graphs = (long int) igraph_vector_ptr_size(&gs);
+    em_list = PyList_New((Py_ssize_t) no_of_graphs);
+    Py_INCREF(em_list);
+    for (i = 0; i < no_of_graphs; i++) {
+      long int j;
+      long int no_of_edges = (long int) igraph_ecount(VECTOR(gs)[i]);
+      PyObject *emi = PyList_New((Py_ssize_t) no_of_edges);
+      Py_INCREF(emi);
+      for (j = 0; j < no_of_edges; j++) {
+        igraph_vector_t *map = VECTOR(*edgemaps)[j];
+        PyList_SetItem(emi, (Py_ssize_t) j, PyLong_FromLong(VECTOR(*map)[j]));
+      }
+      PyList_SetItem(em_list, (Py_ssize_t) i, emi);
+    }
+    igraph_vector_ptr_destroy(edgemaps);
+  }
+
+  /* this is correct as long as attributes are not copied by the
+   * operator. if they are copied, the initialization should not empty
+   * the attribute hashes */
+  o = (igraphmodule_GraphObject*) igraphmodule_Graph_from_igraph_t(&g);
+
+  if (with_edgemaps) {
+    /* wrap in a dictionary */
+    PyObject * str_graph = PyUnicode_FromString("graph");
+    PyObject * str_edgemaps = PyUnicode_FromString("edgemaps");
+    Py_INCREF(str_graph);
+    Py_INCREF(str_edgemaps);
+    result = PyDict_New();
+    Py_INCREF(result);
+    PyDict_SetItem(result, str_graph, (PyObject *) o);
+    PyDict_SetItem(result, str_edgemaps, em_list);
+  }
+  else {
+    result = (PyObject *) o;
+  }
+
+  return (PyObject *) result;
+}
+
+

--- a/src/_igraph/operators.h
+++ b/src/_igraph/operators.h
@@ -25,6 +25,7 @@
 
 #include <Python.h>
 
+PyObject* igraphmodule__disjoint_union(PyObject* self, PyObject* args, PyObject* kwds);
 PyObject* igraphmodule__union(PyObject* self, PyObject* args, PyObject* kwds);
 PyObject* igraphmodule__intersection(PyObject* self, PyObject* args, PyObject* kwds);
 

--- a/src/_igraph/operators.h
+++ b/src/_igraph/operators.h
@@ -25,7 +25,7 @@
 
 #include <Python.h>
 
-PyObject* igraphmodule__union(PyObject* graphs, PyObject* with_edgemaps_o);
-PyObject* igraphmodule__intersection(PyObject* graphs, PyObject* with_edgemaps_o);
+PyObject* igraphmodule__union(PyObject* self, PyObject* args, PyObject* kwds);
+PyObject* igraphmodule__intersection(PyObject* self, PyObject* args, PyObject* kwds);
 
 #endif

--- a/src/_igraph/operators.h
+++ b/src/_igraph/operators.h
@@ -1,0 +1,31 @@
+/* -*- mode: C -*-  */
+/*
+   IGraph library.
+   Copyright (C) 2006-2012  Tamas Nepusz <ntamas@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+
+*/
+
+#ifndef PYTHON_OPERATORS_H
+#define PYTHON_OPERATORS_H
+
+#include <Python.h>
+
+PyObject* igraphmodule__union(PyObject* graphs, PyObject* with_edgemaps_o);
+PyObject* igraphmodule__intersection(PyObject* graphs, PyObject* with_edgemaps_o);
+
+#endif

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -3303,7 +3303,7 @@ class Graph(GraphBase):
             elif other == 1:
                 return self
             elif other > 1:
-                return self.disjoint_union([self]*(other-1))
+                return self.disjoint_union([self] * (other - 1))
             else:
                 return NotImplemented
 
@@ -3601,28 +3601,48 @@ class Graph(GraphBase):
         """
         return str(GraphSummary(self, verbosity, width, *args, **kwds))
 
-    def intersection(self, other, byname='auto'):
-        '''intersection(graphs)
+    def disjoint_union(self, other):
+        '''disjoint_union(self, other)
 
-        Creates the intersection of two (or more) graphs.
+        Creates the disjoint union of two (or more) graphs.
 
-        @param graphs: the list of graphs to be intersected with
+        @param graphs: graph or list of graphs to be united with
         the current one.
-        @param byname: whether to use vertex names instead of ids. See
-        L{igraph.intersection} for details.
+        @return: the disjoint union graph
         '''
-        return intersection([self, other], byname=byname)
+        if isinstance(other, GraphBase):
+            other = [other]
+        return disjoint_union([self] + other)
 
     def union(self, other, byname='auto'):
-        '''union(graphs)
+        '''union(self, other)
 
         Creates the union of two (or more) graphs.
-        @param graphs: the list of graphs to be united with
+
+        @param graphs: graph or list of graphs to be united with
         the current one.
         @param byname: whether to use vertex names instead of ids. See
         L{igraph.union} for details.
+        @return: the union graph
         '''
-        return union([self, other], byname=byname)
+        if isinstance(other, GraphBase):
+            other = [other]
+        return union([self] + other, byname=byname)
+
+    def intersection(self, other, byname='auto'):
+        '''intersection(self, other)
+
+        Creates the intersection of two (or more) graphs.
+
+        @param other: graph or list of graphs to be intersected with
+        the current one.
+        @param byname: whether to use vertex names instead of ids. See
+        L{igraph.intersection} for details.
+        @return: the intersection graph
+        '''
+        if isinstance(other, GraphBase):
+            other = [other]
+        return intersection([self] + other, byname=byname)
 
     _format_mapping = {
           "ncol":       ("Read_Ncol", "write_ncol"),

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -3089,23 +3089,26 @@ class Graph(GraphBase):
             vertices = vertices.copy()
             vertices.iloc[:, 0].fillna('NA', inplace=True)
 
-        names = np.unique(edges.values[:, :2])
+        names_edges = np.unique(edges.values[:, :2])
 
-        if vertices is not None:
-            names_edges = names
+        if vertices is None:
+            names = names_edges
+        else:
             if vertices.shape[1] < 1:
                 raise ValueError('vertices has no columns')
 
-            names = vertices.iloc[:, 0].astype(str)
+            names_vertices = vertices.iloc[:, 0].astype(str)
 
-            if names.duplicated().any():
+            if names_vertices.duplicated().any():
                 raise ValueError('Vertex names must be unique')
 
-            if len(np.setdiff1d(names_edges, names.values)):
+            names_vertices = names_vertices.values
+
+            if len(np.setdiff1d(names_edges, names_vertices)):
                 raise ValueError(
                     'Some vertices in the edge DataFrame are missing from vertices DataFrame')
 
-            names = names.values
+            names = names_vertices
 
         # create graph
         g = Graph(n=len(names), directed=directed)
@@ -3129,9 +3132,9 @@ class Graph(GraphBase):
 
         # edge attributes
         if edges.shape[1] > 2:
-            for e, (_, attr) in zip(g.es, edges.iloc[:, 2:]):
-                for an, av in attr.items():
-                    e[an] = av
+            for e, (_, attr) in zip(g.es, edges.iloc[:, 2:].iterrows()):
+                for a_name, a_value in attr.items():
+                    e[a_name] = a_value
 
         return g
 
@@ -3380,7 +3383,7 @@ class Graph(GraphBase):
         elif isinstance(other, tuple) and len(other) == 2:
             self.delete_edges([other])
         elif isinstance(other, list):
-            if len(other)>0:
+            if len(other) > 0:
                 if isinstance(other[0], tuple):
                     self.delete_edges(other)
                 elif isinstance(other[0], (int, long, basestring)):
@@ -3419,7 +3422,7 @@ class Graph(GraphBase):
         elif isinstance(other, tuple) and len(other) == 2:
             result.delete_edges([other])
         elif isinstance(other, list):
-            if len(other)>0:
+            if len(other) > 0:
                 if isinstance(other[0], tuple):
                     result.delete_edges(other)
                 elif isinstance(other[0], (int, long, basestring)):

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -41,6 +41,7 @@ from igraph.datatypes import *
 from igraph.formula import *
 from igraph.layout import *
 from igraph.matching import *
+from igraph.operators import *
 from igraph.statistics import *
 from igraph.summary import *
 from igraph.utils import *

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -3601,6 +3601,29 @@ class Graph(GraphBase):
         """
         return str(GraphSummary(self, verbosity, width, *args, **kwds))
 
+    def intersection(self, other, byname='auto'):
+        '''intersection(graphs)
+
+        Creates the intersection of two (or more) graphs.
+
+        @param graphs: the list of graphs to be intersected with
+        the current one.
+        @param byname: whether to use vertex names instead of ids. See
+        L{igraph.intersection} for details.
+        '''
+        return intersection([self, other], byname=byname)
+
+    def union(self, other, byname='auto'):
+        '''union(graphs)
+
+        Creates the union of two (or more) graphs.
+        @param graphs: the list of graphs to be united with
+        the current one.
+        @param byname: whether to use vertex names instead of ids. See
+        L{igraph.union} for details.
+        '''
+        return union([self, other], byname=byname)
+
     _format_mapping = {
           "ncol":       ("Read_Ncol", "write_ncol"),
           "lgl":        ("Read_Lgl", "write_lgl"),

--- a/src/igraph/operators.py
+++ b/src/igraph/operators.py
@@ -113,10 +113,10 @@ def union(graphs, byname='auto'):
 
     # If any graph has any edge attributes, we need edgemaps
     edgemaps = any(len(g.edge_attributes()) for g in graphs)
-    res = newgraphs[0].union(newgraphs[1:], edgemaps=edgemaps)
+    res = _union(newgraphs, edgemaps=edgemaps)
     if edgemaps:
         gu = res['graph']
-        maps = res['edgemaps']
+        edgemaps = res['edgemaps']
     else:
         gu = res
 
@@ -294,7 +294,12 @@ def intersection(graphs, byname='auto', keep_all_vertices=True):
 
     # If any graph has any edge attributes, we need edgemaps
     edgemaps = any(len(g.edge_attributes()) for g in graphs)
-    gu = newgraphs[0].intersection(newgraphs[1:], edgemaps=edgemaps)
+    res = _intersection(newgraphs, edgemaps=edgemaps)
+    if edgemaps:
+        gu = res['graph']
+        edgemaps = res['edgemaps']
+    else:
+        gu = res
 
     # Graph attributes
     a_first = {}

--- a/src/igraph/operators.py
+++ b/src/igraph/operators.py
@@ -192,6 +192,7 @@ def union(graphs, byname='auto'):
                         vals[iu] = avi
                         continue
                     if vals[iu] != avi:
+                        print(g, g.vs['name'], emap, avi, iu, vals[iu])
                         conflict = True
                         break
                 if conflict:

--- a/src/igraph/operators.py
+++ b/src/igraph/operators.py
@@ -113,6 +113,7 @@ def union(graphs, byname='auto'):
     else:
         newgraphs = graphs
 
+    # How are edges mapped around??
     gu = newgraphs[0].union(newgraphs[1:])
 
     # Graph attributes
@@ -136,7 +137,7 @@ def union(graphs, byname='auto'):
             gu[f'{an}_{ig}'] = av
 
     # Vertex attributes
-    attrs = set([g.vertex_attributes() for g in newgraphs])
+    attrs = set([g.vertex_attributes() for g in newgraphs]) - set(['name'])
     nve = gu.vcounts()
     for an in attrs:
         # Check for conflicts at at least one vertex

--- a/src/igraph/operators.py
+++ b/src/igraph/operators.py
@@ -88,8 +88,6 @@ def union(graphs, byname='auto'):
         return graphs[0].copy()
     # Now there are at least two graphs
 
-    # TODO: edgemap??
-
     if byname:
         allnames = [g.vs['name'] for g in graphs]
         uninames = list(set.union(*(set(an) for an in allnames)))
@@ -113,8 +111,14 @@ def union(graphs, byname='auto'):
     else:
         newgraphs = graphs
 
-    # How are edges mapped around??
-    gu = newgraphs[0].union(newgraphs[1:])
+    # If any graph has any edge attributes, we need edgemaps
+    edgemaps = any(len(g.edge_attributes()) for g in graphs)
+    res = newgraphs[0].union(newgraphs[1:], edgemaps)
+    if edgemaps:
+        gu = res['graph']
+        maps = res['edgemaps']
+    else:
+        gu = res
 
     # Graph attributes
     a_first = {}
@@ -164,8 +168,8 @@ def union(graphs, byname='auto'):
                 gu.vs[f'{an}_{ig}'] = g.vs[an]
 
     # Edge attributes
-    # We need a map from the original edges to the union edges to do this
-    # TODO
+    if edgemaps:
+        # TODO: apply the edgemaps
 
     return gu
 

--- a/src/igraph/operators.py
+++ b/src/igraph/operators.py
@@ -129,7 +129,7 @@ def union(graphs, byname='auto'):
         for an in g.attributes():
             av = g[an]
             # No conflicts
-            if an not in gu.attributes:
+            if an not in gu.attributes():
                 a_first[an] = ig
                 gu[an] = av
                 continue
@@ -264,12 +264,11 @@ def intersection(graphs, byname='auto', keep_all_vertices=True):
 
         if keep_all_vertices:
             uninames = list(set.union(*(set(an) for an in allnames)))
-            permutation_map = {x: i for i, x in enumerate(uninames)}
         else:
-            #TODO
-            pass
+            uninames = list(set.intersection(*(set(an) for an in allnames)))
+        permutation_map = {x: i for i, x in enumerate(uninames)}
 
-        nve = len(uninames)
+        nv = len(uninames)
         newgraphs = []
         for g, an in zip(graphs, allnames):
             # Make a copy
@@ -279,16 +278,15 @@ def intersection(graphs, byname='auto', keep_all_vertices=True):
                 # Add the missing vertices
                 v_missing = list(set(uninames) - set(an))
                 ng.add_vertices(v_missing)
-
-                # Reorder vertices to match uninames
-                # vertex k -> p[k]
-                permutation = [permutation_map[x] for x in ng.vs['name']]
-                ng = ng.permute_vertices(permutation)
-
             else:
-                # Delete the vertices
-                #TODO
-                pass
+                # Delete the private vertices
+                v_private = list(set(an) - set(uninames))
+                ng.delete_vertices(v_private)
+
+            # Reorder vertices to match uninames
+            # vertex k -> p[k]
+            permutation = [permutation_map[x] for x in ng.vs['name']]
+            ng = ng.permute_vertices(permutation)
 
             newgraphs.append(ng)
     else:
@@ -310,7 +308,7 @@ def intersection(graphs, byname='auto', keep_all_vertices=True):
         for an in g.attributes():
             av = g[an]
             # No conflicts
-            if an not in gu.attributes:
+            if an not in gu.attributes():
                 a_first[an] = ig
                 gu[an] = av
                 continue

--- a/src/igraph/operators.py
+++ b/src/igraph/operators.py
@@ -143,7 +143,9 @@ def union(graphs, byname='auto'):
             gu['{:}_{:}'.format(an, ig)] = av
 
     # Vertex attributes
-    attrs = set.union(*[set(g.vertex_attributes()) for g in newgraphs]) - set(['name'])
+    if byname:
+        gu.vs['name'] = uninames
+    attrs = set.union(*(set(g.vertex_attributes()) for g in newgraphs)) - set(['name'])
     nve = gu.vcount()
     for an in attrs:
         # Check for conflicts at at least one vertex
@@ -152,9 +154,12 @@ def union(graphs, byname='auto'):
         for g in newgraphs:
             if an in g.vertex_attributes():
                 for i, avi in enumerate(g.vs[an]):
+                    if avi is None:
+                        continue
                     if vals[i] is None:
                         vals[i] = avi
-                    elif vals[i] != avi:
+                        continue
+                    if vals[i] != avi:
                         conflict = True
                         break
             if conflict:
@@ -171,7 +176,7 @@ def union(graphs, byname='auto'):
 
     # Edge attributes
     if edgemaps:
-        attrs = set.union([set(g.edge_attributes()) for g in newgraphs])
+        attrs = set.union(*(set(g.edge_attributes()) for g in newgraphs))
         ne = gu.ecount()
         for an in attrs:
             # Check for conflicts at at least one edge
@@ -181,9 +186,12 @@ def union(graphs, byname='auto'):
                 if an not in g.edge_attributes():
                     continue
                 for iu, avi in zip(emap, g.es[an]):
+                    if avi is None:
+                        continue
                     if vals[iu] is None:
                         vals[iu] = avi
-                    elif vals[iu] != avi:
+                        continue
+                    if vals[iu] != avi:
                         conflict = True
                         break
                 if conflict:
@@ -322,7 +330,9 @@ def intersection(graphs, byname='auto', keep_all_vertices=True):
             gu['{:}_{:}'.format(an, ig)] = av
 
     # Vertex attributes
-    attrs = set.union(*[set(g.vertex_attributes()) for g in newgraphs]) - set(['name'])
+    if byname:
+        gu.vs['name'] = uninames
+    attrs = set.union(*(set(g.vertex_attributes()) for g in newgraphs)) - set(['name'])
     nv = gu.vcount()
     for an in attrs:
         # Check for conflicts at at least one vertex
@@ -332,9 +342,12 @@ def intersection(graphs, byname='auto', keep_all_vertices=True):
             if an not in g.vertex_attributes():
                 continue
             for i, avi in enumerate(g.vs[an]):
+                if avi is None:
+                    continue
                 if vals[i] is None:
                     vals[i] = avi
-                elif vals[i] != avi:
+                    continue
+                if vals[i] != avi:
                     conflict = True
                     break
             if conflict:
@@ -351,7 +364,7 @@ def intersection(graphs, byname='auto', keep_all_vertices=True):
 
     # Edge attributes
     if edgemaps:
-        attrs = set.union([set(g.edge_attributes()) for g in newgraphs])
+        attrs = set.union(*(set(g.edge_attributes()) for g in newgraphs))
         ne = gu.ecount()
         for an in attrs:
             # Check for conflicts at at least one edge
@@ -363,9 +376,12 @@ def intersection(graphs, byname='auto', keep_all_vertices=True):
                 for iu, avi in zip(emap, g.es[an]):
                     if iu == -1:
                         continue
+                    if avi is None:
+                        continue
                     if vals[iu] is None:
                         vals[iu] = avi
-                    elif vals[iu] != avi:
+                        continue
+                    if vals[iu] != avi:
                         conflict = True
                         break
                 if conflict:

--- a/src/igraph/operators.py
+++ b/src/igraph/operators.py
@@ -32,6 +32,8 @@ Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
 # pylint: disable-msg=W0401
 # W0401: wildcard import
 from igraph._igraph import *
+from igraph._igraph import _union
+from igraph._igraph import _intersection
 
 from collections import defaultdict, Counter
 from warnings import warn
@@ -113,7 +115,7 @@ def union(graphs, byname='auto'):
 
     # If any graph has any edge attributes, we need edgemaps
     edgemaps = any(len(g.edge_attributes()) for g in graphs)
-    res = _union(newgraphs, edgemaps=edgemaps)
+    res = _union(newgraphs, edgemaps)
     if edgemaps:
         gu = res['graph']
         edgemaps = res['edgemaps']
@@ -137,12 +139,12 @@ def union(graphs, byname='auto'):
                 # New conflict
                 a_num.add(an)
                 igf = a_first[an]
-                gu[f'{an}_{igf}'] = gu.pop(an)
-            gu[f'{an}_{ig}'] = av
+                gu['{:}_{:}'.format(an, igf)] = gu.pop(an)
+            gu['{:}_{:}'.format(an, ig)] = av
 
     # Vertex attributes
-    attrs = set([g.vertex_attributes() for g in newgraphs]) - set(['name'])
-    nve = gu.vcounts()
+    attrs = set.union(*[set(g.vertex_attributes()) for g in newgraphs]) - set(['name'])
+    nve = gu.vcount()
     for an in attrs:
         # Check for conflicts at at least one vertex
         conflict = False
@@ -165,12 +167,12 @@ def union(graphs, byname='auto'):
         # There is a conflict, name after the graph number
         for ig, g in enumerate(newgraphs, 1):
             if an in g.vertex_attributes():
-                gu.vs[f'{an}_{ig}'] = g.vs[an]
+                gu.vs['{:}_{:}'.format(an, ig)] = g.vs[an]
 
     # Edge attributes
     if edgemaps:
         attrs = set.union([set(g.edge_attributes()) for g in newgraphs])
-        ne = gu.ecounts()
+        ne = gu.ecount()
         for an in attrs:
             # Check for conflicts at at least one edge
             conflict = False
@@ -199,7 +201,7 @@ def union(graphs, byname='auto'):
                 vals = [None for i in range(ne)]
                 for iu, avi in zip(emap, g.es[an]):
                     vals[iu] = avi
-                gu.es[f'{an}_{ig}'] = vals
+                gu.es['{:}_{:}'.format(an, ig)] = vals
 
     return gu
 
@@ -294,7 +296,7 @@ def intersection(graphs, byname='auto', keep_all_vertices=True):
 
     # If any graph has any edge attributes, we need edgemaps
     edgemaps = any(len(g.edge_attributes()) for g in graphs)
-    res = _intersection(newgraphs, edgemaps=edgemaps)
+    res = _intersection(newgraphs, edgemaps)
     if edgemaps:
         gu = res['graph']
         edgemaps = res['edgemaps']
@@ -318,12 +320,12 @@ def intersection(graphs, byname='auto', keep_all_vertices=True):
                 # New conflict
                 a_num.add(an)
                 igf = a_first[an]
-                gu[f'{an}_{igf}'] = gu.pop(an)
-            gu[f'{an}_{ig}'] = av
+                gu['{:}_{:}'.format(an, igf)] = gu.pop(an)
+            gu['{:}_{:}'.format(an, ig)] = av
 
     # Vertex attributes
-    attrs = set([g.vertex_attributes() for g in newgraphs]) - set(['name'])
-    nv = gu.vcounts()
+    attrs = set.union(*[set(g.vertex_attributes()) for g in newgraphs]) - set(['name'])
+    nv = gu.vcount()
     for an in attrs:
         # Check for conflicts at at least one vertex
         conflict = False
@@ -347,12 +349,12 @@ def intersection(graphs, byname='auto', keep_all_vertices=True):
         # There is a conflict, name after the graph number
         for ig, g in enumerate(newgraphs, 1):
             if an in g.vertex_attributes():
-                gu.vs[f'{an}_{ig}'] = g.vs[an]
+                gu.vs['{:}_{:}'.format(an, ig)] = g.vs[an]
 
     # Edge attributes
     if edgemaps:
         attrs = set.union([set(g.edge_attributes()) for g in newgraphs])
-        ne = gu.ecounts()
+        ne = gu.ecount()
         for an in attrs:
             # Check for conflicts at at least one edge
             conflict = False
@@ -385,6 +387,6 @@ def intersection(graphs, byname='auto', keep_all_vertices=True):
                     if iu == -1:
                         continue
                     vals[iu] = avi
-                gu.es[f'{an}_{ig}'] = vals
+                gu.es['{:}_{:}'.format(an, ig)] = vals
 
     return gu

--- a/src/igraph/operators.py
+++ b/src/igraph/operators.py
@@ -113,7 +113,7 @@ def union(graphs, byname='auto'):
 
     # If any graph has any edge attributes, we need edgemaps
     edgemaps = any(len(g.edge_attributes()) for g in graphs)
-    res = newgraphs[0].union(newgraphs[1:], edgemaps)
+    res = newgraphs[0].union(newgraphs[1:], edgemaps=edgemaps)
     if edgemaps:
         gu = res['graph']
         maps = res['edgemaps']
@@ -262,7 +262,9 @@ def intersection(graphs, byname='auto', keep_all_vertices=True):
     else:
         newgraphs = graphs
 
-    gu = newgraphs[0].intersection(newgraphs[1:])
+    # If any graph has any edge attributes, we need edgemaps
+    edgemaps = any(len(g.edge_attributes()) for g in graphs)
+    gu = newgraphs[0].intersection(newgraphs[1:], edgemaps=edgemaps)
 
     # Graph attributes
     # TODO

--- a/src/igraph/operators.py
+++ b/src/igraph/operators.py
@@ -1,0 +1,227 @@
+# vim:ts=4:sw=4:sts=4:et
+# -*- coding: utf-8 -*-
+"""
+IGraph library.
+
+@undocumented: deprecated, _graphmethod, _add_proxy_methods, _layout_method_wrapper,
+               _3d_version_for
+"""
+
+from __future__ import with_statement
+
+__license__ = u"""
+Copyright (C) 2006-2012  Tamás Nepusz <ntamas@gmail.com>
+Pázmány Péter sétány 1/a, 1117 Budapest, Hungary
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA
+"""
+
+# pylint: disable-msg=W0401
+# W0401: wildcard import
+from igraph._igraph import *
+
+from warnings import warn
+
+
+def union(graphs, byname='auto'):
+    """Graph union.
+
+    The union of two or more graphs is created. The graphs may have identical
+    or overlapping vertex sets. Edges which are included in at least one graph
+    will be part of the new graph.
+
+    This function keeps the attributes of all graphs. All graph, vertex and
+    edge attributes are copied to the result. If an attribute is present in
+    multiple graphs and would result a name clash, then this attribute is
+    renamed by adding suffixes: _1, _2, etc.
+
+    The 'name' vertex attribute is treated specially if the operation is
+    performed based on symbolic vertex names. In this case 'name' must be
+    present in all graphs, and it is not renamed in the result graph.
+
+    An error is generated if some input graphs are directed and others are
+    undirected.
+
+    @param graph: list of graphs. A lazy sequence is not acceptable.
+    @param byname: bool or 'auto' specifying the function behaviour with
+      respect to names vertices (i.e. vertices with the 'name' attribute). If
+      False, ignore vertex names. If True, merge vertices based on names. If
+      'auto', use True if all graphs have named vertices and False otherwise
+      (in the latter case, a warning is generated too).
+    @return: the union graph
+    """
+
+    if any(not isinstance(g, GraphBase) for g in graphs):
+        raise TypeError('Not all elements are graphs')
+
+    if byname not in (True, False, 'auto'):
+        raise ValueError('"byname" should be a bool or "auto"')
+
+    ngr = len(graphs)
+    n_named = sum(g.is_named() for g in graphs)
+    if byname == 'auto':
+        byname = n_named == ngr
+        if n_named not in (0, ngr):
+            warn("Some, but not all graphs are named, not using vertex names")
+    elif byname and (n_named != ngr):
+        raise AttributeError("Some graphs are not named")
+    # Now we know that byname is only used is all graphs are named
+
+    # Trivial cases
+    if ngr == 0:
+        return None
+    if ngr == 1:
+        return graphs[0]
+    # Now there are at least two graphs
+
+    if byname:
+        allnames = [g.vs['name'] for g in graphs]
+        uninames = list(set.union(*(set(an) for an in allnames)))
+        permutation_map = {x: i for i, x in enumerate(uninames)}
+        nve = len(uninames)
+        newgraphs = []
+        for g, an in zip(graphs, allnames):
+            # Make a copy
+            ng = g.copy()
+
+            # Add the missing vertices
+            v_missing = list(set(uninames) - set(an))
+            ng.add_vertices(v_missing)
+
+            # Reorder vertices to match uninames
+            # vertex k -> p[k]
+            permutation = [permutation_map[x] for x in ng.vs['name']]
+            ng = ng.permute_vertices(permutation)
+
+            newgraphs.append(ng)
+    else:
+        newgraphs = graphs
+
+    gu = newgraphs[0].union(newgraphs[1:])
+
+    # Graph attributes
+    # TODO
+
+    # Vertex attributes
+    # TODO
+
+    # Edge attributes
+    # TODO
+
+    return gu
+
+
+def intersection(graphs, byname='auto', keep_all_vertices=True):
+    """Graph intersection.
+
+    The intersection of two or more graphs is created. The graphs may have
+    identical or overlapping vertex sets. Edges which are included in all
+    graphs will be part of the new graph.
+
+    This function keeps the attributes of all graphs. All graph, vertex and
+    edge attributes are copied to the result. If an attribute is present in
+    multiple graphs and would result a name clash, then this attribute is
+    renamed by adding suffixes: _1, _2, etc.
+
+    The 'name' vertex attribute is treated specially if the operation is
+    performed based on symbolic vertex names. In this case 'name' must be
+    present in all graphs, and it is not renamed in the result graph.
+
+    An error is generated if some input graphs are directed and others are
+    undirected.
+
+    @param graph: list of graphs. A lazy sequence is not acceptable.
+    @param byname: bool or 'auto' specifying the function behaviour with
+      respect to names vertices (i.e. vertices with the 'name' attribute). If
+      False, ignore vertex names. If True, merge vertices based on names. If
+      'auto', use True if all graphs have named vertices and False otherwise
+      (in the latter case, a warning is generated too).
+    @keep_all_vertices: bool specifying if vertices that are not present in all
+      graphs should be kept in the intersection.
+    @return: the intersection graph
+    """
+
+    if any(not isinstance(g, GraphBase) for g in graphs):
+        raise TypeError('Not all elements are graphs')
+
+    if byname not in (True, False, 'auto'):
+        raise ValueError('"byname" should be a bool or "auto"')
+
+    ngr = len(graphs)
+    n_named = sum(g.is_named() for g in graphs)
+    if byname == 'auto':
+        byname = n_named == ngr
+        if n_named not in (0, ngr):
+            warn("Some, but not all graphs are named, not using vertex names")
+    elif byname and (n_named != ngr):
+        raise AttributeError("Some graphs are not named")
+    # Now we know that byname is only used is all graphs are named
+
+    # Trivial cases
+    if ngr == 0:
+        return None
+    if ngr == 1:
+        return graphs[0]
+    # Now there are at least two graphs
+
+    if byname:
+        allnames = [g.vs['name'] for g in graphs]
+
+        if keep_all_vertices:
+            uninames = list(set.union(*(set(an) for an in allnames)))
+            permutation_map = {x: i for i, x in enumerate(uninames)}
+        else:
+            #TODO
+
+        nve = len(uninames)
+        newgraphs = []
+        for g, an in zip(graphs, allnames):
+            # Make a copy
+            ng = g.copy()
+
+            if keep_all_vertices:
+                # Add the missing vertices
+                v_missing = list(set(uninames) - set(an))
+                ng.add_vertices(v_missing)
+
+                # Reorder vertices to match uninames
+                # vertex k -> p[k]
+                permutation = [permutation_map[x] for x in ng.vs['name']]
+                ng = ng.permute_vertices(permutation)
+
+            else:
+                # Delete the vertices
+
+                #TODO
+
+
+            newgraphs.append(ng)
+    else:
+        newgraphs = graphs
+
+    gu = newgraphs[0].intersection(newgraphs[1:])
+
+    # Graph attributes
+    # TODO
+
+    # Vertex attributes
+    # TODO
+
+    # Edge attributes
+    # TODO
+
+    return gu
+

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -179,7 +179,7 @@ class GeneratorTests(unittest.TestCase):
             columns=[0, 1, 'weight'])
 
         g = Graph.DataFrame(edges, directed=False)
-        self.assertTrue(g.es["weight"] == [0.1, 0.4])
+        self.assertTrue(g.es["weight"] == [0.4, 0.1])
 
         vertices = pd.DataFrame(
             [['A', 'blue'], ['B', 'yellow'], ['C', 'blue']],
@@ -187,12 +187,6 @@ class GeneratorTests(unittest.TestCase):
 
         g = Graph.DataFrame(edges, directed=True, vertices=vertices)
         self.assertTrue(g.vs['name'] == ['A', 'B', 'C'])
-        self.assertTrue(g.vs["color"] == ['blue', 'yellow', 'blue'])
-        self.assertTrue(g.es["weight"] == [0.4, 0.1])
-
-        vertices.iloc[0, 0] = np.nan
-        g = Graph.DataFrame(edges, directed=True, vertices=vertices)
-        self.assertTrue(g.vs['name'] == ['NA', 'B', 'C'])
         self.assertTrue(g.vs["color"] == ['blue', 'yellow', 'blue'])
         self.assertTrue(g.es["weight"] == [0.4, 0.1])
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -23,6 +23,16 @@ class OperatorTests(unittest.TestCase):
         g = Graph.Tree(7, 2) | Graph.Lattice([7])
         self.assertTrue(g.vcount() == 7 and g.ecount() == 12)
 
+    def testIntersectionMany(self):
+        gs = [Graph.Tree(7, 2), Graph.Lattice([7])]
+        g = intersection(gs)
+        self.assertTrue(g.get_edgelist() == [(0, 1)])
+
+    def testUnionMany(self):
+        gs = [Graph.Tree(7, 2), Graph.Lattice([7])]
+        g = union(gs)
+        self.assertTrue(g.vcount() == 7 and g.ecount() == 12)
+
     def testInPlaceAddition(self):
         g = Graph.Full(3)
         orig = g

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -32,19 +32,51 @@ class OperatorTests(unittest.TestCase):
         gs = [Graph.Tree(7, 2), Graph.Lattice([7])]
         gs[0]['attr'] = 'graph1'
         gs[0].vs['name'] = ['one', 'two', 'three', 'four', 'five', 'six', '7']
-        gs[1].vs['name'] = ['two', 'one', 'three', 'four', 'five', 'six', '7']
+        gs[1].vs['name'] = ['one', 'two', 'three', 'four', 'five', 'six', '7']
         gs[0].vs[0]['attr'] = 'set'
         gs[1].vs[5]['attr'] = 'set_too'
         g = intersection(gs)
+        names = g.vs['name']
         self.assertTrue(g['attr'] == 'graph1')
-        self.assertTrue(g.vs[0]['attr'] == 'set')
-        self.assertTrue(g.vs[5]['attr'] == 'set_too')
-        self.assertTrue(g.get_edgelist() == [(0, 1)])
+        self.assertTrue(g.vs[names.index('one')]['attr'] == 'set')
+        self.assertTrue(g.vs[names.index('six')]['attr'] == 'set_too')
+        self.assertTrue(g.ecount() == 1)
+        self.assertTrue(
+            set(g.get_edgelist()[0]) == set([names.index('one'), names.index('two')]),
+        )
+
+    def testIntersectionManyEdgemap(self):
+        gs = [
+            Graph.Formula('A-B'),
+            Graph.Formula('A-B,C-D'),
+            ]
+        gs[0].es[0]['attr'] = 'set'
+        gs[1].es[1]['attr'] = 'set_too'
+        g = intersection(gs)
+        self.assertTrue(g.es['attr'] == ['set'])
 
     def testUnionMany(self):
-        gs = [Graph.Tree(7, 2), Graph.Lattice([7])]
+        gs = [Graph.Tree(7, 2), Graph.Lattice([7]), Graph.Lattice([7])]
         g = union(gs)
         self.assertTrue(g.vcount() == 7 and g.ecount() == 12)
+
+    def testUnionManyAttributes(self):
+        gs = [
+            Graph.Formula('A-B'),
+            Graph.Formula('A-B,C-D'),
+            ]
+        gs[0]['attr'] = 'graph1'
+        gs[0].vs['attr'] = ['set', 'set_too']
+        gs[0].vs['attr2'] = ['set', 'set_too']
+        gs[1].vs[0]['attr'] = 'set'
+        gs[1].vs[0]['attr2'] = 'conflict'
+        g = union(gs)
+        names = g.vs['name']
+        self.assertTrue(g['attr'] == 'graph1')
+        self.assertTrue(g.vs[names.index('A')]['attr'] == 'set')
+        self.assertTrue(g.vs[names.index('B')]['attr'] == 'set_too')
+        self.assertTrue(g.ecount() == 2)
+        self.assertTrue(sorted(g.vertex_attributes()) == ['attr', 'attr2_1', 'attr2_2', 'name'])
 
     def testInPlaceAddition(self):
         g = Graph.Full(3)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -11,9 +11,9 @@ except ImportError:
 
 class OperatorTests(unittest.TestCase):
     def testMultiplication(self):
-        g = Graph.Full(3)*3
+        g = Graph.Full(3) * 3
         self.assertTrue(g.vcount() == 9 and g.ecount() == 9
-                        and g.clusters().membership == [0,0,0,1,1,1,2,2,2])
+                        and g.clusters().membership == [0, 0, 0, 1, 1, 1, 2, 2, 2])
 
     def testIntersection(self):
         g = Graph.Tree(7, 2) & Graph.Lattice([7])
@@ -22,6 +22,18 @@ class OperatorTests(unittest.TestCase):
     def testIntersectionMethod(self):
         g = Graph.Tree(7, 2).intersection(Graph.Lattice([7]))
         self.assertTrue(g.get_edgelist() == [(0, 1)])
+
+    def testDisjointUnion(self):
+        g1 = Graph.Tree(7, 2)
+        g2 = Graph.Lattice([7])
+
+        # Method
+        g = g1.disjoint_union(g2)
+        self.assertTrue(g.vcount() == 14 and g.ecount() == 13)
+
+        # Module function
+        g = disjoint_union([g1, g2])
+        self.assertTrue(g.vcount() == 14 and g.ecount() == 13)
 
     def testUnion(self):
         g = Graph.Tree(7, 2) | Graph.Lattice([7])

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -28,6 +28,19 @@ class OperatorTests(unittest.TestCase):
         g = intersection(gs)
         self.assertTrue(g.get_edgelist() == [(0, 1)])
 
+    def testIntersectionManyAttributes(self):
+        gs = [Graph.Tree(7, 2), Graph.Lattice([7])]
+        gs[0]['attr'] = 'graph1'
+        gs[0].vs['name'] = ['one', 'two', 'three', 'four', 'five', 'six', '7']
+        gs[1].vs['name'] = ['two', 'one', 'three', 'four', 'five', 'six', '7']
+        gs[0].vs[0]['attr'] = 'set'
+        gs[1].vs[5]['attr'] = 'set_too'
+        g = intersection(gs)
+        self.assertTrue(g['attr'] == 'graph1')
+        self.assertTrue(g.vs[0]['attr'] == 'set')
+        self.assertTrue(g.vs[5]['attr'] == 'set_too')
+        self.assertTrue(g.get_edgelist() == [(0, 1)])
+
     def testUnionMany(self):
         gs = [Graph.Tree(7, 2), Graph.Lattice([7])]
         g = union(gs)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -19,8 +19,16 @@ class OperatorTests(unittest.TestCase):
         g = Graph.Tree(7, 2) & Graph.Lattice([7])
         self.assertTrue(g.get_edgelist() == [(0, 1)])
 
+    def testIntersectionMethod(self):
+        g = Graph.Tree(7, 2).intersection(Graph.Lattice([7]))
+        self.assertTrue(g.get_edgelist() == [(0, 1)])
+
     def testUnion(self):
         g = Graph.Tree(7, 2) | Graph.Lattice([7])
+        self.assertTrue(g.vcount() == 7 and g.ecount() == 12)
+
+    def testUnionMethod(self):
+        g = Graph.Tree(7, 2).union(Graph.Lattice([7]))
         self.assertTrue(g.vcount() == 7 and g.ecount() == 12)
 
     def testIntersectionMany(self):

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -78,6 +78,21 @@ class OperatorTests(unittest.TestCase):
         self.assertTrue(g.ecount() == 2)
         self.assertTrue(sorted(g.vertex_attributes()) == ['attr', 'attr2_1', 'attr2_2', 'name'])
 
+    def testUnionManyEdgemap(self):
+        gs = [
+            Graph.Formula('A-B'),
+            Graph.Formula('C-D, A-B'),
+            ]
+        gs[0].es[0]['attr'] = 'set'
+        gs[1].es[0]['attr'] = 'set_too'
+        g = union(gs)
+        for e in g.es:
+            vnames = [g.vs[e.source]['name'], g.vs[e.target]['name']]
+            if set(vnames) == set(['A', 'B']):
+                self.assertTrue(e['attr'] == 'set')
+            else:
+                self.assertTrue(e['attr'] == 'set_too')
+
     def testInPlaceAddition(self):
         g = Graph.Full(3)
         orig = g


### PR DESCRIPTION
Trying to address #82 and #269 

For now there is a stub of union and one for intersection. Much of the logic (but not all) is in place, details and tests missing.

The obvious question from my side at this stage is about architecture:

1. Is the file `operators.py` an ok place for this?
2. Is it ok to have these two global functions within the `igraph` namespace and then hook a call to them in (to be defined) instance methods of the `Graph` class (i.e. to-be `Graph.union`, `Graph.intersection`)?
3. If 2 is fine, then we can reroute the `__and__` and `__or__` operators into this code path

Thanks!
Fabio