### PR TITLE
DFS and DFS iterator

### DIFF
--- a/src/_igraph/dfsiter.c
+++ b/src/_igraph/dfsiter.c
@@ -1,0 +1,266 @@
+/* -*- mode: C -*-  */
+/* 
+   IGraph library.
+   Copyright (C) 2006-2012  Tamas Nepusz <ntamas@gmail.com>
+   
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA 
+   02110-1301 USA
+
+*/
+
+#include "dfsiter.h"
+#include "common.h"
+#include "error.h"
+#include "py2compat.h"
+#include "vertexobject.h"
+
+/**
+ * \ingroup python_interface
+ * \defgroup python_interface_dfsiter DFS iterator object
+ */
+
+PyTypeObject igraphmodule_DFSIterType;
+
+/**
+ * \ingroup python_interface_dfsiter
+ * \brief Allocate a new DFS iterator object for a given graph and a given root
+ * \param g the graph object being referenced
+ * \param vid the root vertex index
+ * \param advanced whether the iterator should be advanced (returning distance and parent as well)
+ * \return the allocated PyObject
+ */
+PyObject* igraphmodule_DFSIter_new(igraphmodule_GraphObject *g, PyObject *root, igraph_neimode_t mode, igraph_bool_t advanced) {
+  igraphmodule_DFSIterObject* o;
+  long int no_of_nodes, r;
+
+  o=PyObject_GC_New(igraphmodule_DFSIterObject, &igraphmodule_DFSIterType);
+  Py_INCREF(g);
+  o->gref=g;
+  o->graph=&g->g;
+  
+  if (!PyInt_Check(root) && !PyObject_IsInstance(root, (PyObject*)&igraphmodule_VertexType)) {
+    PyErr_SetString(PyExc_TypeError, "root must be integer or igraph.Vertex");
+    return NULL;
+  }
+  
+  no_of_nodes=igraph_vcount(&g->g);
+  o->visited=(char*)calloc(no_of_nodes, sizeof(char));
+  if (o->visited == 0) {
+    PyErr_SetString(PyExc_MemoryError, "out of memory");
+    return NULL;
+  }
+  
+  if (igraph_dqueue_init(&o->queue, 100)) {
+    PyErr_SetString(PyExc_MemoryError, "out of memory");
+    return NULL;
+  }
+  if (igraph_vector_init(&o->neis, 0)) {
+    PyErr_SetString(PyExc_MemoryError, "out of memory");
+    igraph_dqueue_destroy(&o->queue);
+    return NULL;
+  }
+  
+  if (PyInt_Check(root)) {
+    r=PyInt_AsLong(root);
+  } else {
+    r=((igraphmodule_VertexObject*)root)->idx;
+  }
+  /* push the root onto the queue */
+  if (igraph_dqueue_push(&o->queue, r) ||
+      igraph_dqueue_push(&o->queue, 0) ||
+      igraph_dqueue_push(&o->queue, -1)) {
+    igraph_dqueue_destroy(&o->queue);
+    igraph_vector_destroy(&o->neis);
+    PyErr_SetString(PyExc_MemoryError, "out of memory");
+    return NULL;
+  }
+  o->visited[r]=1;
+  
+  if (!igraph_is_directed(&g->g)) mode=IGRAPH_ALL;
+  o->mode=mode;
+  o->advanced=advanced;
+  
+  PyObject_GC_Track(o);
+  
+  RC_ALLOC("DFSIter", o);
+  
+  return (PyObject*)o;
+}
+
+/**
+ * \ingroup python_interface_dfsiter
+ * \brief Support for cyclic garbage collection in Python
+ * 
+ * This is necessary because the \c igraph.DFSIter object contains several
+ * other \c PyObject pointers and they might point back to itself.
+ */
+int igraphmodule_DFSIter_traverse(igraphmodule_DFSIterObject *self,
+				  visitproc visit, void *arg) {
+  int vret;
+
+  RC_TRAVERSE("DFSIter", self);
+  
+  if (self->gref) {
+    vret=visit((PyObject*)self->gref, arg);
+    if (vret != 0) return vret;
+  }
+  
+  return 0;
+}
+
+/**
+ * \ingroup python_interface_dfsiter
+ * \brief Clears the iterator's subobject (before deallocation)
+ */
+int igraphmodule_DFSIter_clear(igraphmodule_DFSIterObject *self) {
+  PyObject *tmp;
+
+  PyObject_GC_UnTrack(self);
+  
+  tmp=(PyObject*)self->gref;
+  self->gref=NULL;
+  Py_XDECREF(tmp);
+
+  igraph_dqueue_destroy(&self->queue);
+  igraph_vector_destroy(&self->neis);
+  free(self->visited);
+  self->visited=0;
+  
+  return 0;
+}
+
+/**
+ * \ingroup python_interface_dfsiter
+ * \brief Deallocates a Python representation of a given DFS iterator object
+ */
+void igraphmodule_DFSIter_dealloc(igraphmodule_DFSIterObject* self) {
+  igraphmodule_DFSIter_clear(self);
+
+  RC_DEALLOC("DFSIter", self);
+  
+  PyObject_GC_Del(self);
+}
+
+PyObject* igraphmodule_DFSIter_iter(igraphmodule_DFSIterObject* self) {
+  Py_INCREF(self);
+  return (PyObject*)self;
+}
+
+PyObject* igraphmodule_DFSIter_iternext(igraphmodule_DFSIterObject* self) {
+  if (!igraph_dqueue_empty(&self->queue)) {
+    /* pop the last element on the queue */
+    igraph_integer_t vid = (igraph_integer_t)igraph_dqueue_pop(&self->queue);
+    igraph_integer_t dist = (igraph_integer_t)igraph_dqueue_pop(&self->queue);
+    igraph_integer_t parent = (igraph_integer_t)igraph_dqueue_pop(&self->queue);
+    long int i;
+    
+    /* look for neighbors */
+    if (igraph_neighbors(self->graph, &self->neis, vid, self->mode)) {
+      igraphmodule_handle_igraph_error();
+      return NULL;
+    }
+	
+
+    /* FIXME: change into DFS algorithm */
+    for (i=0; i<igraph_vector_size(&self->neis); i++) {
+      igraph_integer_t neighbor = (igraph_integer_t)VECTOR(self->neis)[i];
+      if (self->visited[neighbor]==0) {
+	self->visited[neighbor]=1;
+	if (igraph_dqueue_push(&self->queue, neighbor) ||
+	    igraph_dqueue_push(&self->queue, dist+1) ||
+	    igraph_dqueue_push(&self->queue, vid)) {
+	  igraphmodule_handle_igraph_error();
+	  return NULL;
+	}
+      }
+    }
+
+    if (self->advanced) {
+      PyObject *vertexobj, *parentobj;
+      vertexobj = igraphmodule_Vertex_New(self->gref, vid);
+      if (!vertexobj)
+        return NULL;
+      if (parent >= 0) {
+        parentobj = igraphmodule_Vertex_New(self->gref, parent);
+        if (!parentobj)
+            return NULL;
+      } else {
+        Py_INCREF(Py_None);
+        parentobj=Py_None;
+      }
+      return Py_BuildValue("NlN", vertexobj, (long int)dist, parentobj);
+    } else {
+      return igraphmodule_Vertex_New(self->gref, vid);
+    }
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * \ingroup python_interface_dfsiter
+ * Method table for the \c igraph.DFSIter object
+ */
+PyMethodDef igraphmodule_DFSIter_methods[] = {
+  {NULL}
+};
+
+/** \ingroup python_interface_dfsiter
+ * Python type object referencing the methods Python calls when it performs various operations on
+ * a DFS iterator of a graph
+ */
+PyTypeObject igraphmodule_DFSIterType =
+{
+  PyVarObject_HEAD_INIT(0, 0)
+  "igraph.DFSIter",                         // tp_name
+  sizeof(igraphmodule_DFSIterObject),       // tp_basicsize
+  0,                                        // tp_itemsize
+  (destructor)igraphmodule_DFSIter_dealloc, // tp_dealloc
+  0,                                        // tp_print
+  0,                                        // tp_getattr
+  0,                                        // tp_setattr
+  0,                                        /* tp_compare (2.x) / tp_reserved (3.x) */
+  0,                                        // tp_repr
+  0,                                        // tp_as_number
+  0,                                        // tp_as_sequence
+  0,                                        // tp_as_mapping
+  0,                                        // tp_hash
+  0,                                        // tp_call
+  0,                                        // tp_str
+  0,                                        // tp_getattro
+  0,                                        // tp_setattro
+  0,                                        // tp_as_buffer
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, // tp_flags
+  "igraph DFS iterator object",             // tp_doc
+  (traverseproc) igraphmodule_DFSIter_traverse, /* tp_traverse */
+  (inquiry) igraphmodule_DFSIter_clear,     /* tp_clear */
+  0,                                        // tp_richcompare
+  0,                                        // tp_weaklistoffset
+  (getiterfunc)igraphmodule_DFSIter_iter,   /* tp_iter */
+  (iternextfunc)igraphmodule_DFSIter_iternext, /* tp_iternext */
+  0,                                        /* tp_methods */
+  0,                                        /* tp_members */
+  0,                                        /* tp_getset */
+  0,                                        /* tp_base */
+  0,                                        /* tp_dict */
+  0,                                        /* tp_descr_get */
+  0,                                        /* tp_descr_set */
+  0,                                        /* tp_dictoffset */
+  0,                                        /* tp_init */
+  0,                                        /* tp_alloc */
+  0,                                        /* tp_new */
+  0,                                        /* tp_free */
+};
+

--- a/src/_igraph/dfsiter.c
+++ b/src/_igraph/dfsiter.c
@@ -1,7 +1,7 @@
 /* -*- mode: C -*-  */
 /* 
    IGraph library.
-   Copyright (C) 2006-2012  Tamas Nepusz <ntamas@gmail.com>
+   Copyright (C) 2020  The igraph development team
    
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/_igraph/dfsiter.h
+++ b/src/_igraph/dfsiter.h
@@ -1,0 +1,53 @@
+/* -*- mode: C -*-  */
+/* 
+   IGraph library.
+   Copyright (C) 2006-2012  Tamas Nepusz <ntamas@gmail.com>
+   
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA 
+   02110-1301 USA
+
+*/
+
+#ifndef PYTHON_DFSITER_H
+#define PYTHON_DFSITER_H
+
+#include <Python.h>
+#include "graphobject.h"
+
+/**
+ * \ingroup python_interface_dfsiter
+ * \brief A structure representing a DFS iterator of a graph
+ */
+typedef struct
+{
+  PyObject_HEAD
+  igraphmodule_GraphObject* gref;
+  igraph_dqueue_t queue;
+  igraph_vector_t neis;
+  igraph_t *graph;
+  char *visited;
+  igraph_neimode_t mode;
+  igraph_bool_t advanced;
+} igraphmodule_DFSIterObject;
+
+PyObject* igraphmodule_DFSIter_new(igraphmodule_GraphObject *g, PyObject *o, igraph_neimode_t mode, igraph_bool_t advanced);
+int igraphmodule_DFSIter_traverse(igraphmodule_DFSIterObject *self,
+				  visitproc visit, void *arg);
+int igraphmodule_DFSIter_clear(igraphmodule_DFSIterObject *self);
+void igraphmodule_DFSIter_dealloc(igraphmodule_DFSIterObject* self);
+
+extern PyTypeObject igraphmodule_DFSIterType;
+
+#endif

--- a/src/_igraph/dfsiter.h
+++ b/src/_igraph/dfsiter.h
@@ -34,7 +34,7 @@ typedef struct
 {
   PyObject_HEAD
   igraphmodule_GraphObject* gref;
-  igraph_dqueue_t queue;
+  igraph_stack_t stack;
   igraph_vector_t neis;
   igraph_t *graph;
   char *visited;

--- a/src/_igraph/dfsiter.h
+++ b/src/_igraph/dfsiter.h
@@ -1,7 +1,7 @@
 /* -*- mode: C -*-  */
 /* 
    IGraph library.
-   Copyright (C) 2006-2012  Tamas Nepusz <ntamas@gmail.com>
+   Copyright (C) 2020  The igraph development team
    
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -23,6 +23,7 @@
 #include "attributes.h"
 #include "arpackobject.h"
 #include "bfsiter.h"
+#include "dfsiter.h"
 #include "common.h"
 #include "convert.h"
 #include "edgeseqobject.h"
@@ -9918,6 +9919,23 @@ PyObject *igraphmodule_Graph_unfold_tree(igraphmodule_GraphObject * self,
   CREATE_GRAPH(result_o, result);
 
   return Py_BuildValue("NN", result_o, mapping_o);
+}
+
+/** \ingroup python_interface_graph
+ * \brief Constructs a depth first search (DFS) iterator of the graph
+ */
+PyObject *igraphmodule_Graph_dfsiter(igraphmodule_GraphObject * self,
+                                     PyObject * args, PyObject * kwds)
+{
+  char *kwlist[] = { "vid", "mode", "advanced", NULL };
+  PyObject *root, *adv = Py_False, *mode_o = Py_None;
+  igraph_neimode_t mode = IGRAPH_OUT;
+
+  if (!PyArg_ParseTupleAndKeywords
+      (args, kwds, "O|OO", kwlist, &root, &mode_o, &adv))
+    return NULL;
+  if (igraphmodule_PyObject_to_neimode_t(mode_o, &mode)) return NULL;
+  return igraphmodule_DFSIter_new(self, root, mode, PyObject_IsTrue(adv));
 }
 
 /**********************************************************************

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -14545,7 +14545,7 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
    "  vertex in DFS order in every step. If C{True}, the iterator\n"
    "  returns the distance of the vertex from the root and the\n"
    "  parent of the vertex in the DFS tree as well.\n"
-   "@return: the DFS iterator as an L{igraph.BFSIter} object.\n"},
+   "@return: the DFS iterator as an L{igraph.DFSIter} object.\n"},
 
   /////////////////
   // CONVERSIONS //

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -14535,6 +14535,17 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
    "  returns the distance of the vertex from the root and the\n"
    "  parent of the vertex in the BFS tree as well.\n"
    "@return: the BFS iterator as an L{igraph.BFSIter} object.\n"},
+  {"dfsiter", (PyCFunction) igraphmodule_Graph_dfsiter,
+   METH_VARARGS | METH_KEYWORDS,
+   "dfsiter(vid, mode=OUT, advanced=False)\n\n"
+   "Constructs a depth first search (DFS) iterator of the graph.\n\n"
+   "@param vid: the root vertex ID\n"
+   "@param mode: either L{IN} or L{OUT} or L{ALL}.\n"
+   "@param advanced: if C{False}, the iterator returns the next\n"
+   "  vertex in DFS order in every step. If C{True}, the iterator\n"
+   "  returns the distance of the vertex from the root and the\n"
+   "  parent of the vertex in the DFS tree as well.\n"
+   "@return: the DFS iterator as an L{igraph.BFSIter} object.\n"},
 
   /////////////////
   // CONVERSIONS //

--- a/src/_igraph/igraphmodule.c
+++ b/src/_igraph/igraphmodule.c
@@ -26,6 +26,7 @@
 #include "arpackobject.h"
 #include "attributes.h"
 #include "bfsiter.h"
+#include "dfsiter.h"
 #include "common.h"
 #include "convert.h"
 #include "edgeobject.h"
@@ -764,6 +765,8 @@ extern PyObject* igraphmodule_arpack_options_default;
     INITERROR;
   if (PyType_Ready(&igraphmodule_BFSIterType) < 0)
     INITERROR;
+  if (PyType_Ready(&igraphmodule_DFSIterType) < 0)
+    INITERROR;
   if (PyType_Ready(&igraphmodule_ARPACKOptionsType) < 0)
     INITERROR;
 
@@ -783,6 +786,7 @@ extern PyObject* igraphmodule_arpack_options_default;
   /* Add the types to the core module */
   PyModule_AddObject(m, "GraphBase", (PyObject*)&igraphmodule_GraphType);
   PyModule_AddObject(m, "BFSIter", (PyObject*)&igraphmodule_BFSIterType);
+  PyModule_AddObject(m, "DFSIter", (PyObject*)&igraphmodule_DFSIterType);
   PyModule_AddObject(m, "ARPACKOptions", (PyObject*)&igraphmodule_ARPACKOptionsType);
   PyModule_AddObject(m, "Edge", (PyObject*)&igraphmodule_EdgeType);
   PyModule_AddObject(m, "EdgeSeq", (PyObject*)&igraphmodule_EdgeSeqType);

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -3240,16 +3240,10 @@ class Graph(GraphBase):
         # go down the rabbit hole
         while stack:
             vid = stack[-1]
-            if mode == IN:
-                edges = self.vs[vid].in_edges()
-            else:
-                edges = self.vs[vid].out_edges()
-            for edge in edges:
-                neighbor = edge.target
-                if neighbor == vid:
-                    neighbor = edge.source
+            neighbors = self.neighbors(vid, mode=mode)
+            for neighbor in neighbors:
                 if not added[neighbor]:
-                    # Add hanging neighbor
+                    # Add hanging subtree neighbor
                     stack.append(neighbor)
                     vids.append(neighbor)
                     parents.append(vid)

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -3212,6 +3212,56 @@ class Graph(GraphBase):
         return super(Graph, self).get_incidence(types, *args, **kwds)
 
     ###########################
+    # DFS (C version will come soon)
+    def dfs(self, vid, mode=OUT):
+        """Conducts a depth first search (DFS) on the graph.
+
+        @param vid: the root vertex ID
+        @param mode: either L{IN} or L{OUT} or L{ALL}, ignored
+          for undirected graphs.
+        @return: a tuple with the following items:
+           - The vertex IDs visited (in order)
+           - The parent of every vertex in the DFS
+        """
+        nv = self.vcount()
+        added = [False for v in range(nv)]
+        stack = []
+
+        # prepare output
+        vids = []
+        parents = []
+
+        # ok start from vid
+        stack.append(vid)
+        vids.append(vid)
+        parents.append(vid)
+        added[vid] = True
+
+        # go down the rabbit hole
+        while stack:
+            vid = stack[-1]
+            if mode == IN:
+                edges = self.vs[vid].in_edges()
+            else:
+                edges = self.vs[vid].out_edges()
+            for edge in edges:
+                neighbor = edge.target
+                if neighbor == vid:
+                    neighbor = edge.source
+                if not added[neighbor]:
+                    # Add hanging neighbor
+                    stack.append(neighbor)
+                    vids.append(neighbor)
+                    parents.append(vid)
+                    added[neighbor] = True
+                    break
+            else:
+                # No neighbor found, end of subtree
+                stack.pop()
+
+        return (vids, parents)
+
+    ###########################
     # ctypes support
 
     @property

--- a/tests/test_iterators.py
+++ b/tests/test_iterators.py
@@ -2,6 +2,12 @@ import unittest
 from igraph import *
 
 class IteratorTests(unittest.TestCase):
+    def testBFS(self):
+        g = Graph.Tree(10, 2)
+        vs, layers, ps = g.bfs(0)
+        self.assertEqual(vs, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        self.assertEqual(ps, [0, 0, 0, 1, 1, 2, 2, 3, 3, 4])
+
     def testBFSIter(self):
         g = Graph.Tree(10, 2)
         vs = [v.index for v in g.bfsiter(0)]
@@ -14,29 +20,23 @@ class IteratorTests(unittest.TestCase):
              (4, 2, 1), (5, 2, 2), (6, 2, 2),
              (7, 3, 3), (8, 3, 3), (9, 3, 4)])
 
+    def testDFS(self):
+        g = Graph.Tree(10, 2)
+        vs, ps = g.dfs(0)
+        self.assertEqual(vs, [0, 1, 3, 7, 8, 4, 9, 2, 5, 6])
+        self.assertEqual(ps, [0, 0, 1, 3, 3, 1, 4, 0, 2, 2])
+
     def testDFSIter(self):
         g = Graph.Tree(10, 2)
         vs = [v.index for v in g.dfsiter(0)]
-        self.assertEqual(vs, [0, 1, 3, 4, 7, 8, 9, 2, 5, 6])
+        self.assertEqual(vs, [0, 1, 3, 7, 8, 4, 9, 2, 5, 6])
         vs = [(v.index, d, p) for v, d, p in g.dfsiter(0, advanced=True)]
         vs = [(v, d, p.index) for v, d, p in vs if p is not None]
         self.assertEqual(
             vs,
-            [(1, 1, 0), (3, 2, 1), (4, 2, 1),
-             (7, 3, 3), (8, 3, 3), (9, 3, 4),
+            [(1, 1, 0), (3, 2, 1), (7, 3, 3),
+             (8, 3, 3), (4, 2, 1), (9, 3, 4),
              (2, 1, 0), (5, 2, 2), (6, 2, 2)])
-
-    def testBFS(self):
-        g = Graph.Tree(10, 2)
-        vs, layers, ps = g.bfs(0)
-        self.assertEqual(vs, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-        self.assertEqual(ps, [0, 0, 0, 1, 1, 2, 2, 3, 3, 4])
-
-    def testDFS(self):
-        g = Graph.Tree(10, 2)
-        vs, layers, ps = g.dfs(0)
-        self.assertEqual(vs, [0, 1, 3, 4, 7, 8, 9, 2, 5, 6])
-        self.assertEqual(ps, [0, 0, 1, 1, 3, 3, 4, 0, 2, 2])
 
 
 def suite():

--- a/tests/test_iterators.py
+++ b/tests/test_iterators.py
@@ -2,14 +2,41 @@ import unittest
 from igraph import *
 
 class IteratorTests(unittest.TestCase):
-    def testBFS(self):
-        g=Graph.Tree(10, 2)
-        vs=[v.index for v in g.bfsiter(0)]
+    def testBFSIter(self):
+        g = Graph.Tree(10, 2)
+        vs = [v.index for v in g.bfsiter(0)]
         self.assertEqual(vs, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-        vs=[(v.index,dist,parent) for v,dist,parent in g.bfsiter(0, advanced=True)]
-        vs=[(v,d,p.index) for v,d,p in vs if p != None]
-        self.assertEqual(vs, [(1,1,0), (2,1,0), (3,2,1), (4,2,1), \
-          (5,2,2), (6,2,2), (7,3,3), (8,3,3), (9,3,4)])
+        vs = [(v.index, d, p) for v, d, p in g.bfsiter(0, advanced=True)]
+        vs = [(v, d, p.index) for v, d, p in vs if p is not None]
+        self.assertEqual(
+            vs,
+            [(1, 1, 0), (2, 1, 0), (3, 2, 1),
+             (4, 2, 1), (5, 2, 2), (6, 2, 2),
+             (7, 3, 3), (8, 3, 3), (9, 3, 4)])
+
+    def testDFSIter(self):
+        g = Graph.Tree(10, 2)
+        vs = [v.index for v in g.dfsiter(0)]
+        self.assertEqual(vs, [0, 1, 3, 4, 7, 8, 9, 2, 5, 6])
+        vs = [(v.index, d, p) for v, d, p in g.dfsiter(0, advanced=True)]
+        vs = [(v, d, p.index) for v, d, p in vs if p is not None]
+        self.assertEqual(
+            vs,
+            [(1, 1, 0), (3, 2, 1), (4, 2, 1),
+             (7, 3, 3), (8, 3, 3), (9, 3, 4),
+             (2, 1, 0), (5, 2, 2), (6, 2, 2)])
+
+    def testBFS(self):
+        g = Graph.Tree(10, 2)
+        vs, layers, ps = g.bfs(0)
+        self.assertEqual(vs, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        self.assertEqual(ps, [0, 0, 0, 1, 1, 2, 2, 3, 3, 4])
+
+    def testDFS(self):
+        g = Graph.Tree(10, 2)
+        vs, layers, ps = g.dfs(0)
+        self.assertEqual(vs, [0, 1, 3, 4, 7, 8, 9, 2, 5, 6])
+        self.assertEqual(ps, [0, 0, 1, 1, 3, 3, 4, 0, 2, 2])
 
 
 def suite():
@@ -19,7 +46,6 @@ def suite():
 def test():
     runner = unittest.TextTestRunner()
     runner.run(suite())
-    
+
 if __name__ == "__main__":
     test()
-


### PR DESCRIPTION
This PR aims at addressing #295.

In that issue a trivial Python implementation using recursion is proposed. That would be simplest, of course, but potentially runs into a few issues:

- max depth of the Python call stack
- perhaps speed

The way BFS is coded is via a two-tier system:

- a function that returns a whole list of the traversal, which relies on the C core `igraph_i_bfs`
- an iterator that reimplements the basic algorithm (a queue)

Both live at the C API interface with Python and are not recursive, therefore should be more performant than an equivalent, pure Python recursive call.

This PR aims at either of the following three:
1. implementing DFS and its iterator the same way that BFS is implemented
2. take down the whole infrastructure for BFS and substitute it with a simple pure-python recursive call and do the same for DFS
3. leave BFS the way it is and use the pure Python recursion for DFS, along the lines of "better slow than nothing"

Any preferences out there among these?