### PR TITLE
Clear function and improve delete vertices and edges

### DIFF
--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -565,10 +565,21 @@ PyObject *igraphmodule_Graph_add_vertices(igraphmodule_GraphObject * self,
  */
 PyObject *igraphmodule_Graph_delete_vertices(igraphmodule_GraphObject * self,
                                              PyObject * args, PyObject * kwds) {
-  PyObject *list;
+  PyObject *list = 0;
   igraph_vs_t vs;
 
-  if (!PyArg_ParseTuple(args, "O", &list)) return NULL;
+  if (!PyArg_ParseTuple(args, "|O", &list)) return NULL;
+
+  /* no arguments means delete all. */
+  
+  /*Py_None also means all for now, but it is deprecated */
+  if (list == Py_None) {
+        PyErr_Warn(PyExc_DeprecationWarning, "Graph.delete_vertices(None) is "
+                   "deprecated since igraph 0.8.3, please use "
+                   "Graph.delete_vertices() instead");
+  }
+
+  /* this already converts no arguments and Py_None to all vertices */
   if (igraphmodule_PyObject_to_vs_t(list, &vs, &self->g, 0, 0)) return NULL;
 
   if (igraph_delete_vertices(&self->g, vs)) {

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -571,7 +571,7 @@ PyObject *igraphmodule_Graph_delete_vertices(igraphmodule_GraphObject * self,
   if (!PyArg_ParseTuple(args, "|O", &list)) return NULL;
 
   /* no arguments means delete all. */
-  
+
   /*Py_None also means all for now, but it is deprecated */
   if (list == Py_None) {
         PyErr_Warn(PyExc_DeprecationWarning, "Graph.delete_vertices(None) is "
@@ -640,13 +640,23 @@ PyObject *igraphmodule_Graph_add_edges(igraphmodule_GraphObject * self,
 PyObject *igraphmodule_Graph_delete_edges(igraphmodule_GraphObject * self,
                                           PyObject * args, PyObject * kwds)
 {
-  PyObject *list;
+  PyObject *list = 0;
   igraph_es_t es;
   static char *kwlist[] = { "edges", NULL };
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &list))
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kwlist, &list))
     return NULL;
 
+  /* no arguments means delete all. */
+
+  /*Py_None also means all for now, but it is deprecated */
+  if (list == Py_None) {
+        PyErr_Warn(PyExc_DeprecationWarning, "Graph.delete_vertices(None) is "
+                   "deprecated since igraph 0.8.3, please use "
+                   "Graph.delete_vertices() instead");
+  }
+
+  /* this already converts no arguments and Py_None to all vertices */
   if (igraphmodule_PyObject_to_es_t(list, &es, &self->g, 0)) {
     /* something bad happened during conversion, return immediately */
     return NULL;
@@ -12060,7 +12070,7 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
    "delete_vertices(vs)\n\n"
    "Deletes vertices and all its edges from the graph.\n\n"
    "@param vs: a single vertex ID or the list of vertex IDs\n"
-   "  to be deleted.\n"},
+   "  to be deleted. No argument deletes all vertices.\n"},
 
   /* interface to igraph_add_edges */
   {"add_edges", (PyCFunction) igraphmodule_Graph_add_edges,
@@ -12079,7 +12089,8 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
    "All vertices will be kept, even if they lose all their edges.\n"
    "Nonexistent edges will be silently ignored.\n\n"
    "@param es: the list of edges to be removed. Edges are identifed by\n"
-   "  edge IDs. L{EdgeSeq} objects are also accepted here.\n"},
+   "  edge IDs. L{EdgeSeq} objects are also accepted here. No argument\n"
+   "  deletes all edges.\n"},
 
   /* interface to igraph_degree */
   {"degree", (PyCFunction) igraphmodule_Graph_degree,

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -382,33 +382,30 @@ class Graph(GraphBase):
         """Deletes some edges from the graph.
 
         The set of edges to be deleted is determined by the positional and
-        keyword arguments. If the functions is called without any arguments,
+        keyword arguments. If the function is called without any arguments,
         all edges are deleted. If any keyword argument is present, or the
         first positional argument is callable, an edge sequence is derived by
         calling L{EdgeSeq.select} with the same positional and keyword
         arguments. Edges in the derived edge sequence will be removed.
         Otherwise the first positional argument is considered as follows:
 
-          - C{None} - deletes all edges
-            @deprecated: replaced by no arguments since igraph 0.8.3
+          - C{None} - deletes all edges (deprecated since 0.8.3)
           - a single integer - deletes the edge with the given ID
           - a list of integers - deletes the edges denoted by the given IDs
           - a list of 2-tuples - deletes the edges denoted by the given
             source-target vertex pairs. When multiple edges are present
             between a given source-target vertex pair, only one is removed.
+
+        @deprecated: L{Graph.delete_edges(None)} has been replaced by
+        L{Graph.delete_edges()} - with no arguments - since igraph 0.8.3.
         """
         if len(args) == 0 and len(kwds) == 0:
-            # This means delete all
-            edge_seq = None
-        elif len(kwds) > 0 or (hasattr(args[0], "__call__") and \
-                not isinstance(args[0], EdgeSeq)):
+            return GraphBase.delete_edges(self)
+
+        if len(kwds) > 0 or (callable(args[0]) and not isinstance(args[0], EdgeSeq)):
             edge_seq = self.es(*args, **kwds)
         else:
             edge_seq = args[0]
-            if edge_seq is None:
-                deprecated(
-                    "Graph.delete_edges(None) is deprecated since igraph "
-                    "0.8.3, please use Graph.delete_edges() instead")
         return GraphBase.delete_edges(self, edge_seq)
 
     def indegree(self, *args, **kwds):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -282,6 +282,17 @@ class BasicTests(unittest.TestCase):
         g.delete_edges()
         self.assertEqual(0, g.ecount())
 
+    def testClear(self):
+        g = Graph.Famous("petersen")
+        g["name"] = list("petersen")
+
+        # Clearing the graph
+        g.clear()
+
+        self.assertEqual(0, g.vcount())
+        self.assertEqual(0, g.ecount())
+        self.assertEqual([], g.attributes())
+
     def testGraphGetEid(self):
         g = Graph.Famous("petersen")
         g.vs["name"] = list("ABCDEFGHIJ")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -178,6 +178,10 @@ class BasicTests(unittest.TestCase):
         self.assertRaises(ValueError, g.delete_vertices, "no-such-vertex")
         self.assertRaises(InternalError, g.delete_vertices, 2)
 
+        # Delete all vertices
+        g.delete_vertices()
+        self.assertEqual(0, g.vcount())
+
     def testAddEdge(self):
         g = Graph()
         g.add_vertices(["spam", "bacon", "eggs", "ham"])
@@ -273,6 +277,10 @@ class BasicTests(unittest.TestCase):
         self.assertRaises(ValueError, g.delete_edges, [(0, 2)])
         self.assertRaises(ValueError, g.delete_edges, [("A", "C")])
         self.assertRaises(ValueError, g.delete_edges, [(0, 15)])
+
+        # Delete all edges
+        g.delete_edges()
+        self.assertEqual(0, g.ecount())
 
     def testGraphGetEid(self):
         g = Graph.Famous("petersen")


### PR DESCRIPTION
This implements `Graph.clear()` which clears vertices, edges, and attributes.

It also deprecates `Graph.delete_vertices(None)` and `Graph.delete_edges(None)`, opting instead for `Graph.delete_vertices()` and `Graph.delete_edges()`.

Tests still missing, hence draft.

edit: added tests and reviewed, so it should be ready for merge now