### PR TITLE
Documentation on graph visualization

### DIFF
--- a/doc/source/visualisation.rst
+++ b/doc/source/visualisation.rst
@@ -37,7 +37,7 @@ and methods:
 
 Indexing and slicing can be performed and returns the coordinates of the requested vertices:
 
->>> coords_subgraph = layout[:2]  # Coordinate of the first vertex
+>>> coords_subgraph = layout[:2]  # Coordinates of the first two vertices
 
 .. note:: The returned object is a list of lists with the coordinates, not an `igraph.layout.Layout`
    object. You can wrap the result into such an object easily:
@@ -110,6 +110,13 @@ In both cases, you can add an argument `layout` to the `plot` function to specif
 
 >>> layout = g.layout("kamada_kawai")
 >>> ig.plot(g, layout=layout)
+
+It is also possible to use the name of the layout algorithm directly:
+
+>>> ig.plot(g, layout="kamada_kawai")
+
+If the layout is left unspecified, igraph uses the dedicated `layout_auto()` function, which chooses between one of several
+possible layouts based on the number of vertices and edges.
 
 You can specify additional options such as vertex and edge color, size, and labels via additional arguments, e.g.:
 

--- a/doc/source/visualisation.rst
+++ b/doc/source/visualisation.rst
@@ -2,4 +2,86 @@
 
 Visualisation of graphs
 =======================
-|igraph|
+|igraph| includes functionality to visualize graphs. There are two main components: graph layouts and graph plotting.
+
+In the following examples, we will assume |igraph| is imported as `ig` and a
+:class:`Graph` object has been previously created, e.g.:
+
+>>> import igraph as ig
+>>> g = ig.Graph(edges=[[0, 1], [2, 3]])
+
+Read the `API documentation`_ for details on each function and class.
+
+Graph layouts
++++++++++++++
+A graph *layout* is a low-dimensional (usually: 2 dimensional) representation of a graph. Different layouts for the same
+graph can be computed and typically preserve or highlight distinct properties of the graph itself. Some layouts only make
+sense for specific kinds of graphs, such as trees.
+
+|igraph| offers several graph layouts. The general function to compute a graph layout is :meth:`Graph.layout`:
+
+>>> layout = g.layout(layout='auto')
+
+See below for a list of supported layouts. The resulting object is an instance of `igraph.layout.Layout` and has some
+useful properties:
+
+- :attr:`Layout.coords`: the coordinates of the vertices in the layout (each row is a vertex)
+- :attr:`Layout.dim`: the number of dimensions of the embedding (usually 2)
+
+and methods:
+
+- :meth:`Layout.boundaries` the rectangle with the extreme coordinates of the layout
+- :meth:`Layout.bounding_box` the boundary, but as an `igraph.drawing.utils.BoundingBox` (see below)
+- :meth:`Layout.centroid` the coordinates of the centroid of the graph layout
+
+Indexing and slicing can be performed and returns the coordinates of the requested vertices:
+
+>>> coords_subgraph = layout[:2]  # Coordinate of the first vertex
+
+.. note:: The returned object is a list of lists with the coordinates, not an `igraph.layout.Layout`
+   object. You can wrap the result into such an object easily:
+ 
+   >>> layout_subgraph = ig.Layout(coords=layout[:2])
+
+It is possible to perform linear transformations to the layout:
+
+- :meth:`Layout.translate`
+- :meth:`Layout.center`
+- :meth:`Layout.scale`
+- :meth:`Layout.fit_into`
+- :meth:`Layout.rotate`
+- :meth:`Layout.mirror`
+
+as well as a generic nonlinear transformation via:
+
+- :meth:`Layout.transform`
+
+The following layouts are supported:
+
+- `Graph.layout_bipartite`: bipartite layout
+- `Graph.layout_circle`: circular/spherical layout
+- `Graph.layout_davidson_harel`: Davidson-Harel layout
+- `Graph.layout_drl`: DrL layout for large graphs (2D and 3D)
+- `Graph.layout_fruchterman_reingold`: Fruchterman-Reingold layout (2D and 3D)
+- `Graph.layout_grid`: regular grid layout in 2D
+- `Graph.layout_grid_3d`: regular grid layout in 3D
+- `Graph.layout_graphopt`: the graphopt algorithm
+- `Graph.layout_kamada_kawai`: Kamada-Kawai layout (2D and 3D)
+- `Graph.layout_lgl`: Large Graph Layout
+- `Graph.layout_mds`: multidimensional scaling layout
+- `Graph.layout_random`: random layout (2D and 3D)
+- `Graph.layout_reingold_tilford`: Reingold-Tilford *tree* layout
+- `Graph.layout_reingold_tilford_circular`: circular Reingold-Tilford *tree* layout
+- `Graph.layout_star`: star layout
+- `Graph.layout_sugiyama`: Sugiyama layout
+
+More might be added in the future, based on request.
+
+Graph plotting
+++++++++++++++
+Once the layout of a graph has been computed, |igraph| can assist with the plotting itself.
+
+
+
+
+.. _API documentation: https://igraph.org/python/doc/igraph-module.html

--- a/doc/source/visualisation.rst
+++ b/doc/source/visualisation.rst
@@ -1,4 +1,5 @@
+.. include:: include/global.rst
+
 Visualisation of graphs
 =======================
-
-.. note:: TODO. This is a placeholder section; it is not written yet.
+|igraph|

--- a/doc/source/visualisation.rst
+++ b/doc/source/visualisation.rst
@@ -1,5 +1,6 @@
 .. include:: include/global.rst
 
+=======================
 Visualisation of graphs
 =======================
 |igraph| includes functionality to visualize graphs. There are two main components: graph layouts and graph plotting.
@@ -10,10 +11,10 @@ In the following examples, we will assume |igraph| is imported as `ig` and a
 >>> import igraph as ig
 >>> g = ig.Graph(edges=[[0, 1], [2, 3]])
 
-Read the `API documentation`_ for details on each function and class.
+Read the `API documentation`_ for details on each function and class. The `tutorial`_ contains examples to get started.
 
 Graph layouts
-+++++++++++++
+=============
 A graph *layout* is a low-dimensional (usually: 2 dimensional) representation of a graph. Different layouts for the same
 graph can be computed and typically preserve or highlight distinct properties of the graph itself. Some layouts only make
 sense for specific kinds of graphs, such as trees.
@@ -56,32 +57,89 @@ as well as a generic nonlinear transformation via:
 
 - :meth:`Layout.transform`
 
-The following layouts are supported:
+The following regular layouts are supported:
 
-- `Graph.layout_bipartite`: bipartite layout
+- `Graph.layout_star`: star layout
 - `Graph.layout_circle`: circular/spherical layout
-- `Graph.layout_davidson_harel`: Davidson-Harel layout
-- `Graph.layout_drl`: DrL layout for large graphs (2D and 3D)
-- `Graph.layout_fruchterman_reingold`: Fruchterman-Reingold layout (2D and 3D)
 - `Graph.layout_grid`: regular grid layout in 2D
 - `Graph.layout_grid_3d`: regular grid layout in 3D
-- `Graph.layout_graphopt`: the graphopt algorithm
-- `Graph.layout_kamada_kawai`: Kamada-Kawai layout (2D and 3D)
+- `Graph.layout_random`: random layout (2D and 3D)
+
+The following algorithms produce nice layouts for general graphs:
+
+- `Graph.layout_davidson_harel`: Davidson-Harel layout, based on simulated annealing optimization including edge crossings
+- `Graph.layout_drl`: DrL layout for large graphs (2D and 3D), a scalable force-directed layout
+- `Graph.layout_fruchterman_reingold`: Fruchterman-Reingold layout (2D and 3D), a "spring-electric" layout based on classical physics
+- `Graph.layout_graphopt`: the graphopt algorithm, another force-directed layout
+- `Graph.layout_kamada_kawai`: Kamada-Kawai layout (2D and 3D), a "spring" layout based on classical physics
 - `Graph.layout_lgl`: Large Graph Layout
 - `Graph.layout_mds`: multidimensional scaling layout
-- `Graph.layout_random`: random layout (2D and 3D)
-- `Graph.layout_reingold_tilford`: Reingold-Tilford *tree* layout
-- `Graph.layout_reingold_tilford_circular`: circular Reingold-Tilford *tree* layout
-- `Graph.layout_star`: star layout
-- `Graph.layout_sugiyama`: Sugiyama layout
+
+The following algorithms are useful for *trees* (and for Sugiyama *directed acyclic graphs* or *DAGs*):
+
+- `Graph.layout_reingold_tilford`: Reingold-Tilford layout
+- `Graph.layout_reingold_tilford_circular`: circular Reingold-Tilford layout
+- `Graph.layout_sugiyama`: Sugiyama layout, a hierarchical layout
+
+For *bipartite graphs*, there is a dedicated function:
+
+- `Graph.layout_bipartite`: bipartite layout
 
 More might be added in the future, based on request.
 
 Graph plotting
-++++++++++++++
-Once the layout of a graph has been computed, |igraph| can assist with the plotting itself.
+==============
+Once the layout of a graph has been computed, |igraph| can assist with the plotting itself. Plotting happens within a single
+function, `igraph.plot`. This function can be called in two ways:
 
+1. without a filename argument: this generates a temporary file and opens it with the default image viewer:
 
+>>> ig.plot(g)
+
+(see below if you are using this in a `Jupyter`_ notebook).
+
+2. with a filename argument: this stores the graph image in the specified file and does *not* open it automatically. Based on
+   the filename extension, any of the following output formats can be chosen: PNG, PDF, SVG and PostScript:
+
+>>> ig.plot(g, 'myfile.pdf')
+
+.. note:: PNG is a raster image format while PDF, SVG, and Postscript are vector image formats. Choose one of the last three
+   formats if you are planning on refining the image with a vector image editor such as Inkscape or Illustrator.
+
+In both cases, you can add an argument `layout` to the `plot` function to specify a precomputed layout, e.g.:
+
+>>> layout = g.layout("kamada_kawai")
+>>> ig.plot(g, layout=layout)
+
+You can specify additional options such as vertex and edge color, size, and labels via additional arguments, e.g.:
+
+>>> ig.plot(g,
+>>>         vertex_size=20,
+>>>         vertex_color=['blue', 'red', 'green', 'yellow'],
+>>>         vertex_label=['first', 'second', 'third', 'fourth'],
+>>>         edge_width=[1, 4],
+>>>         edge_color=['black', 'grey'],
+>>>         )
+
+See the `tutorial`_ for examples and a full list of options.
+
+Jupyter notebook
+++++++++++++++++
+|igraph| supports inline plots within a `Jupyter`_ notebook. If you are calling `igraph.plot` from a notebook cell, the image
+will be shown inline in the corresponding output cell. Use the `bbox` argument to scale the image while preserving the size
+of the vertices, text, and other artists. For instance, to get a compact plot:
+
+>>> ig.plot(g, bbox=(0, 0, 100, 100))
+
+These inline plots can be either in PNG or SVG format. There is currently an open bug that makes SVG fail if more than one graph
+per notebook is plotted: we are working on a fix for that. In the meanwhile, you can use PNG representation.
+
+Matplotlib interactive plots
+++++++++++++++++++++++++++++
+We are currently working on extending this functionality to play nicely with `matplotlib`_ for interactive graphs. Stay tuned.
 
 
 .. _API documentation: https://igraph.org/python/doc/igraph-module.html
+.. _matplotlib: https://matplotlib.org
+.. _Jupyter: https://jupyter.org/
+.. _tutorial: https://igraph.org/python/doc/tutorial/tutorial.html#layouts-and-plotting

--- a/doc/source/visualisation.rst
+++ b/doc/source/visualisation.rst
@@ -92,16 +92,16 @@ Graph plotting
 Once the layout of a graph has been computed, |igraph| can assist with the plotting itself. Plotting happens within a single
 function, `igraph.plot`.
 
-Open default image viewer
-++++++++++++++++++++++++++++
+Plotting with the default image viewer
+++++++++++++++++++++++++++++++++++++++
 A naked call to `igraph.plot` generates a temporary file and opens it with the default image viewer:
 
 >>> ig.plot(g)
 
 (see below if you are using this in a `Jupyter`_ notebook). This uses the `Cairo`_ library behind the scenes.
 
-Save to file
-++++++++++++
+Saving a plot to a file
++++++++++++++++++++++++
 A call to `igraph.plot` with a `target` argument stores the graph image in the specified file and does *not*
 open it automatically. Based on the filename extension, any of the following output formats can be chosen:
 PNG, PDF, SVG and PostScript:
@@ -111,8 +111,8 @@ PNG, PDF, SVG and PostScript:
 .. note:: PNG is a raster image format while PDF, SVG, and Postscript are vector image formats. Choose one of the last three
    formats if you are planning on refining the image with a vector image editor such as Inkscape or Illustrator.
 
-Matplotlib plots
-++++++++++++++++++++++++++++
+Plotting graphs within Matplotlib figures
++++++++++++++++++++++++++++++++++++++++++
 If the target argument is a `matplotlib`_ axes, the graph will be plotted inside that axes:
 
 >>> import matplotlib.pyplot as plt
@@ -123,8 +123,8 @@ You can then further manipulate the axes and figure however you like via the `ax
 called them). This variant does not use `Cairo`_ directly and might be lacking some features that are available in the
 `Cairo`_ backend: please open an issue on Github to request specific features.
 
-Jupyter notebooks
-+++++++++++++++++++++
+Plotting graphs in Jupyter notebooks
+++++++++++++++++++++++++++++++++++++
 |igraph| supports inline plots within a `Jupyter`_ notebook via both the `Cairo`_ and `matplotlib`_ backend. If you are
 calling `igraph.plot` from a notebook cell without a `matplotlib`_ axes, the image will be shown inline in the corresponding
 output cell. Use the `bbox` argument to scale the image while preserving the size of the vertices, text, and other artists.

--- a/doc/source/visualisation.rst
+++ b/doc/source/visualisation.rst
@@ -90,23 +90,74 @@ More might be added in the future, based on request.
 Graph plotting
 ==============
 Once the layout of a graph has been computed, |igraph| can assist with the plotting itself. Plotting happens within a single
-function, `igraph.plot`. This function can be called in two ways:
+function, `igraph.plot`.
 
-1. without a filename argument: this generates a temporary file and opens it with the default image viewer:
+Open default image viewer
+++++++++++++++++++++++++++++
+A naked call to `igraph.plot` generates a temporary file and opens it with the default image viewer:
 
 >>> ig.plot(g)
 
-(see below if you are using this in a `Jupyter`_ notebook).
+(see below if you are using this in a `Jupyter`_ notebook). This uses the `Cairo`_ library behind the scenes.
 
-2. with a filename argument: this stores the graph image in the specified file and does *not* open it automatically. Based on
-   the filename extension, any of the following output formats can be chosen: PNG, PDF, SVG and PostScript:
+Save to file
+++++++++++++
+A call to `igraph.plot` with a `target` argument stores the graph image in the specified file and does *not*
+open it automatically. Based on the filename extension, any of the following output formats can be chosen:
+PNG, PDF, SVG and PostScript:
 
->>> ig.plot(g, 'myfile.pdf')
+>>> ig.plot(g, target='myfile.pdf')
 
 .. note:: PNG is a raster image format while PDF, SVG, and Postscript are vector image formats. Choose one of the last three
    formats if you are planning on refining the image with a vector image editor such as Inkscape or Illustrator.
 
-In both cases, you can add an argument `layout` to the `plot` function to specify a precomputed layout, e.g.:
+Matplotlib plots
+++++++++++++++++++++++++++++
+If the target argument is a `matplotlib`_ axes, the graph will be plotted inside that axes:
+
+>>> import matplotlib.pyplot as plt
+>>> fig, ax = plt.subplots()
+>>> ig.plot(g, target=ax)
+
+You can then further manipulate the axes and figure however you like via the `ax` and `fig` variables (or whatever you
+called them). This variant does not use `Cairo`_ directly and might be lacking some features that are available in the
+`Cairo`_ backend: please open an issue on Github to request specific features.
+
+Jupyter notebooks
++++++++++++++++++++++
+|igraph| supports inline plots within a `Jupyter`_ notebook via both the `Cairo`_ and `matplotlib`_ backend. If you are
+calling `igraph.plot` from a notebook cell without a `matplotlib`_ axes, the image will be shown inline in the corresponding
+output cell. Use the `bbox` argument to scale the image while preserving the size of the vertices, text, and other artists.
+For instance, to get a compact plot:
+
+>>> ig.plot(g, bbox=(0, 0, 100, 100))
+
+These inline plots can be either in PNG or SVG format. There is currently an open bug that makes SVG fail if more than one graph
+per notebook is plotted: we are working on a fix for that. In the meanwhile, you can use PNG representation.
+
+If you want to use the `matplotlib`_ engine in a Jupyter notebook, you can use the recipe above. First create an axes, then
+tell `igraph.plot` about it via the `target` argument:
+
+>>> import matplotlib.pyplot as plt
+>>> fig, ax = plt.subplots()
+>>> ig.plot(g, target=ax)
+
+Exporting to other graph formats
+++++++++++++++++++++++++++++++++++
+If igraph is missing a certain plotting feature and you cannot wait for us to include it, you can always export your graph
+to a number of formats and use an external graph plotting tool. We support both conversion to file (e.g. DOT format used by
+`graphviz`_) and to popular graph libraries such as `networkx`_ and `graph-tool`_:
+
+>>> dot = g.write('/myfolder/myfile.dot')
+>>> n = g.to_networkx()
+>>> gt = g.to_graph_tool()
+
+You do not need to have any libraries installed if you export to file, but you do need them to convert directly to external
+Python objects (`networkx`_, `graph-tool`_).
+
+Plotting options
+====================
+You can add an argument `layout` to the `plot` function to specify a precomputed layout, e.g.:
 
 >>> layout = g.layout("kamada_kawai")
 >>> ig.plot(g, layout=layout)
@@ -118,7 +169,7 @@ It is also possible to use the name of the layout algorithm directly:
 If the layout is left unspecified, igraph uses the dedicated `layout_auto()` function, which chooses between one of several
 possible layouts based on the number of vertices and edges.
 
-You can specify additional options such as vertex and edge color, size, and labels via additional arguments, e.g.:
+You can also specify vertex and edge color, size, and labels - and more - via additional arguments, e.g.:
 
 >>> ig.plot(g,
 >>>         vertex_size=20,
@@ -130,23 +181,11 @@ You can specify additional options such as vertex and edge color, size, and labe
 
 See the `tutorial`_ for examples and a full list of options.
 
-Jupyter notebook
-++++++++++++++++
-|igraph| supports inline plots within a `Jupyter`_ notebook. If you are calling `igraph.plot` from a notebook cell, the image
-will be shown inline in the corresponding output cell. Use the `bbox` argument to scale the image while preserving the size
-of the vertices, text, and other artists. For instance, to get a compact plot:
-
->>> ig.plot(g, bbox=(0, 0, 100, 100))
-
-These inline plots can be either in PNG or SVG format. There is currently an open bug that makes SVG fail if more than one graph
-per notebook is plotted: we are working on a fix for that. In the meanwhile, you can use PNG representation.
-
-Matplotlib interactive plots
-++++++++++++++++++++++++++++
-We are currently working on extending this functionality to play nicely with `matplotlib`_ for interactive graphs. Stay tuned.
-
-
 .. _API documentation: https://igraph.org/python/doc/igraph-module.html
 .. _matplotlib: https://matplotlib.org
 .. _Jupyter: https://jupyter.org/
 .. _tutorial: https://igraph.org/python/doc/tutorial/tutorial.html#layouts-and-plotting
+.. _Cairo: https://www.cairographics.org
+.. _graphviz: http://www.graphviz.org
+.. _networkx: https://networkx.org/
+.. _graph-tool: https://graph-tool.skewed.de/


### PR DESCRIPTION
Hi guys,

As promised I started drafting some docs on graph visualization via `igraph` (well, `python-igraph` I s'pose).

For now it describes a bit the graph layouts, and I am starting to tackle the plotting itself. So about that, it would be great to make a rough plan of action (beyond docs).

First of all:

https://stackoverflow.com/questions/3285193/how-to-change-backends-in-matplotlib-python

Second, I use ipython with matplotlib and `Qt5Agg` backend (it opens up interactive windows, quite convenient). There are a bunch of other interactive backends. How do we use igraph with those? The current docstrings only describe `cairo` or other static backends,but that seems limiting at best given we have the layout already. I usually just use igraph to get a layout and then do the plotting in a little function, e.g.:

```python
import igraph as ig
import matplotlib.pyplot as plt

g = ig.Graph.Full(3)
layout = g.layout('auto')

def plot_graph(g, layout, ax=None):
    x, y = list(zip(*layout.coords))
    if ax is None:
        fig, ax = plt.subplots()
    else:
       fig = None
    ax.scatter(x, y, s=30, color='black', zorder=10)
    for v1, v2 in g.get_edgelist():
        x1, y1, x2, y2 = x[v1], y[v1], x[v2], y[v2]
       ax.plot([x1, x2], [y1, y2], lw=2, color='black', zorder=9)
    if fig is not None:
        fig.tight_layout()
    return {'fig': fig, 'ax': ax}

plot_graph(g, layout)
```

It seems easy enough to do, is it already part of igraph or, if not, should I add it?

Any suggestions on how to write this second part of the doc page? Or should I first implement this kind of plotting function and then finish this doc PR?

Thanks!
Fabio