### PR TITLE
Prototype for matplotlib graph drawing

### DIFF
--- a/src/igraph/drawing/__init__.py
+++ b/src/igraph/drawing/__init__.py
@@ -452,7 +452,7 @@ def plot(obj, target=None, bbox=(0, 0, 600, 600), *args, **kwds):
 
     @see: Graph.__plot__
     """
-    if (plt is not None) and isinstance(target, plt.Axes):
+    if hasattr(plt, 'Axes') and isinstance(target, plt.Axes):
         result = MatplotlibGraphDrawer(ax=target)
         result.draw(obj, *args, **kwds)
         return

--- a/src/igraph/drawing/edge.py
+++ b/src/igraph/drawing/edge.py
@@ -234,7 +234,6 @@ class ArrowEdgeDrawer(AbstractEdgeDrawer):
             return bezier_cubic(x0,y0, x1,y1, x2,y2, x3,y3, t1)
 
 
-
         # Draw the edge
         ctx.set_source_rgba(*edge.color)
         ctx.set_line_width(edge.width)
@@ -313,14 +312,12 @@ class ArrowEdgeDrawer(AbstractEdgeDrawer):
         # Draw the edge
         ctx.stroke()
 
-
         # Draw the arrow head
         ctx.move_to(x2, y2)
         ctx.line_to(*aux_points[0])
         ctx.line_to(*aux_points[1])
         ctx.line_to(x2, y2)
         ctx.fill()
-
 
 
 class TaperedEdgeDrawer(AbstractEdgeDrawer):

--- a/src/igraph/drawing/graph.py
+++ b/src/igraph/drawing/graph.py
@@ -984,9 +984,9 @@ class MatplotlibGraphDrawer(AbstractGraphDrawer):
         x, y = list(zip(*vcoord))
         ax.scatter(x, y, s=s, c=c, marker=shapes, zorder=vzorder, alpha=alpha)
         if label is not None:
-            for i, lab, lab_size in enumerate(zip(label, label_size)):
+            for i, lab in enumerate(label):
                 xi, yi = x[i], y[i]
-                ax.text(xi, yi, lab, fs=lab_size)
+                ax.text(xi, yi, lab, fontsize=label_size)
 
         # Edge properties
         ne = graph.ecount()

--- a/src/igraph/drawing/utils.py
+++ b/src/igraph/drawing/utils.py
@@ -393,11 +393,11 @@ class FakeModule(object):
     """Fake module that raises an exception for everything"""
 
     def __getattr__(self, _):
-        raise TypeError("plotting not available")
+        raise AttributeError("plotting not available")
     def __call__(self, _):
         raise TypeError("plotting not available")
     def __setattr__(self, key, value):
-        raise TypeError("plotting not available")
+        raise AttributeError("plotting not available")
 
 #####################################################################
 

--- a/src/igraph/drawing/utils.py
+++ b/src/igraph/drawing/utils.py
@@ -423,17 +423,19 @@ def find_matplotlib():
     also trying ``cairocffi`` (a drop-in replacement of ``cairo``).
     Returns a fake module if everything fails.
     """
-    module_names = ["matplotlib"]
-    module = FakeModule()
-    pyplot = FakeModule()
-    for module_name in module_names:
-        try:
-            module = __import__(module_name)
-            pyplot = module.pyplot
-            break
-        except ImportError:
-            pass
-    return module, pyplot
+    try:
+        import matplotlib as mpl
+        has_mpl = True
+    except ImportError:
+        mpl = FakeModule()
+        has_mpl = False
+
+    if has_mpl:
+        import matplotlib.pyplot as plt
+    else:
+        plt = FakeModule()
+
+    return mpl, plt
 
 #####################################################################
 

--- a/src/igraph/drawing/utils.py
+++ b/src/igraph/drawing/utils.py
@@ -418,6 +418,25 @@ def find_cairo():
 
 #####################################################################
 
+def find_matplotlib():
+    """Tries to import the ``cairo`` Python module if it is installed,
+    also trying ``cairocffi`` (a drop-in replacement of ``cairo``).
+    Returns a fake module if everything fails.
+    """
+    module_names = ["matplotlib"]
+    module = FakeModule()
+    pyplot = FakeModule()
+    for module_name in module_names:
+        try:
+            module = __import__(module_name)
+            pyplot = module.pyplot
+            break
+        except ImportError:
+            pass
+    return module, pyplot
+
+#####################################################################
+
 class Point(tuple):
     """Class representing a point on the 2D plane."""
     __slots__ = ()


### PR DESCRIPTION
Hi guys,

Following up on the chat about plotting documentation, I wrote an initial attempt at enabling graph visualization with matplotlib. That is nice because:

1. a lot of people use matplotlib, so it'd be easy for them to customize the plots if needed
2. several matplotlib backgrounds are interactive, so people can zoom/pan in their graphs

The current plotting framework is designed mostly for static figures rather than interactive ones. Moreover, it relies on hooks in other parts of the code to work, e.g.

- `Graph.__plot__`
- `_repr_svg_` and `_repr_png_` for Jupyter (note: they don't work on vanilla ipython on my machine, but they do work in Jupyter)
- a few magical tricks by Cairo such as autocurving of edges

In order to keep the code somewhat clean, I made a separate class for the matplotlib stuff and implemented a simple plotting routine. It is buggy and lacks some features, but gives you the idea. I'm not strongly attached to the code, but I do think we should help our users make interactive graph visualizations, just opening a static image in an external viewer is quite limiting.

Of course, I acknowledge the amazing work @ntamas and perhaps others have done to get the current version to work: in no way I am trying to diminish your accomplishments! We are just trying to improve on top of what we already have, not to dismantle that.

Now there are a few issues with this idea:

- matplotlib does no magic of bending edges, shrinking edges to fit vertex shape edges, or similia, so one has to decide what to do with that
- matplotlib has a long standing feature request to allow a list of shapes to be passed to the scatter function. For the time being, that makes it difficult (not impossible though) to use more than one shape per graph.
- matplotlib does not have, that I am aware of, a very good way of telling the space occupied on the canvas by text - bases on fontsize, font family, etc. so one has to wing it a little

**NOTE**: matplotlib itself can use Cairo as a drawing engine, for both static or interactive (e.g. 'Qt5Cairo', 'TkCairo') plots. However igraph currently hardlinks to Cairo without the matplotlib layer. That has advantages (less deps, autocurve) but also disadvantages (interactions are impossible, that's what pyplot is essentially for). We could think of a special case when matplotlib is selected in igraph but its backend is actually some form of Cairo: in that case we might be able to get the best of both worlds (e.g. autocurve AND interactivity). Does not seem particularly difficult to implement, but yes a little more laborious than just vanilla pyplot.

What do you think? Feedback welcome, thank you!