### PR TITLE
Get pandas DataFrame for vertices and edges

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,9 @@ install:
   # install cibuildwheel
   - pip install cibuildwheel==1.6.1
 
+  # install pandas (optional)
+  - pip install pandas
+
 before_build:
   - git submodule update --init --recursive
 

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -4,7 +4,12 @@ import warnings
 
 from igraph import *
 
-from .utils import temporary_file
+from .utils import temporary_file, skipIf
+
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
 
 
 class ForeignTests(unittest.TestCase):


### PR DESCRIPTION
Adding two methods to `Graph` to export vertices/edges and their names and attributes to pandas DataFrames. Basically vincent code from here:

https://igraph.discourse.group/t/convert-graph-object-to-dataframe/575

with a few changes for corner cases and tests.

Somehow my tests on 2.7 pass but on 3.9 complain they cannot import pandas. I have pandas in my python 3.9 installation, so... well let's see how CI goes.