### PR TITLE
Generate graph from scipy sparse matrix

### DIFF
--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -1939,6 +1939,12 @@ PyObject *igraphmodule_Graph_Adjacency(PyTypeObject * type,
   return (PyObject *) self;
 }
 
+PyObject *igraphmodule_Graph__Adjacency(PyTypeObject * type,
+                                       PyObject * args, PyObject * kwds) {
+  return igraphmodule_Graph_Adjacency(type, args, kwds);
+}
+
+
 /** \ingroup python_interface_graph
  * \brief Generates a graph from the Graph Atlas
  * \return a reference to the newly generated Python igraph object

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -1939,11 +1939,6 @@ PyObject *igraphmodule_Graph_Adjacency(PyTypeObject * type,
   return (PyObject *) self;
 }
 
-PyObject *igraphmodule_Graph__Adjacency(PyTypeObject * type,
-                                       PyObject * args, PyObject * kwds) {
-  return igraphmodule_Graph_Adjacency(type, args, kwds);
-}
-
 
 /** \ingroup python_interface_graph
  * \brief Generates a graph from the Graph Atlas

--- a/src/_igraph/graphobject.h
+++ b/src/_igraph/graphobject.h
@@ -77,7 +77,6 @@ PyObject* igraphmodule_Graph_predecessors(igraphmodule_GraphObject *self, PyObje
 PyObject* igraphmodule_Graph_get_eid(igraphmodule_GraphObject *self, PyObject *args, PyObject *kwds);
 
 PyObject* igraphmodule_Graph_Adjacency(PyTypeObject *type, PyObject *args, PyObject *kwds);
-PyObject* igraphmodule_Graph__Adjacency(PyTypeObject *type, PyObject *args, PyObject *kwds);
 PyObject* igraphmodule_Graph_Asymmetric_Preference(PyTypeObject *type, PyObject *args, PyObject *kwds);
 PyObject* igraphmodule_Graph_Atlas(PyTypeObject *type, PyObject *args);
 PyObject* igraphmodule_Graph_Barabasi(PyTypeObject *type, PyObject *args, PyObject *kwds);

--- a/src/_igraph/graphobject.h
+++ b/src/_igraph/graphobject.h
@@ -77,6 +77,7 @@ PyObject* igraphmodule_Graph_predecessors(igraphmodule_GraphObject *self, PyObje
 PyObject* igraphmodule_Graph_get_eid(igraphmodule_GraphObject *self, PyObject *args, PyObject *kwds);
 
 PyObject* igraphmodule_Graph_Adjacency(PyTypeObject *type, PyObject *args, PyObject *kwds);
+PyObject* igraphmodule_Graph__Adjacency(PyTypeObject *type, PyObject *args, PyObject *kwds);
 PyObject* igraphmodule_Graph_Asymmetric_Preference(PyTypeObject *type, PyObject *args, PyObject *kwds);
 PyObject* igraphmodule_Graph_Atlas(PyTypeObject *type, PyObject *args);
 PyObject* igraphmodule_Graph_Barabasi(PyTypeObject *type, PyObject *args, PyObject *kwds);

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -46,9 +46,9 @@ from igraph.summary import *
 from igraph.utils import *
 from igraph.version import __version__, __version_info__
 from igraph.sparse_matrix import (
-        _graph_from_sparse_matrix,
-        _graph_from_weighted_sparse_matrix,
-        )
+    _graph_from_sparse_matrix,
+    _graph_from_weighted_sparse_matrix,
+)
 
 import os
 import math
@@ -2195,14 +2195,20 @@ class Graph(GraphBase):
 
         if (sparse is not None) and isinstance(matrix, sparse.spmatrix):
             return _graph_from_weighted_sparse_matrix(
-                klass, matrix, mode=mode, attr=attr,
+                klass,
+                matrix,
+                mode=mode,
+                attr=attr,
             )
 
         if (np is not None) and isinstance(matrix, np.ndarray):
             matrix = matrix.tolist()
 
         return super().WeightedAdjacency(
-            matrix, mode=mode, attr=attr, loops=loops,
+            matrix,
+            mode=mode,
+            attr=attr,
+            loops=loops,
         )
 
     def write_dimacs(self, f, source=None, target=None, capacity="capacity"):

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -41,6 +41,7 @@ from igraph.formula import *
 from igraph.layout import *
 from igraph.matching import *
 from igraph.operators import *
+from igraph.sparse_matrix import *
 from igraph.statistics import *
 from igraph.summary import *
 from igraph.utils import *
@@ -2104,6 +2105,50 @@ class Graph(GraphBase):
             graph = klass.Weighted_Adjacency(matrix, *args, **kwds)
 
         return graph
+
+    @classmethod
+    def Adjacency(klass, matrix, mode=ADJ_DIRECTED):
+        """Generates a graph from its adjacency matrix.
+
+        @param matrix: the adjacency matrix. Possible types are:
+          - a list of lists
+          - a numpy 2D array or matrix (will be converted to list of lists)
+          - a scipy.sparse matrix (will be converted to a COO matrix, but not
+            to a dense matrix)
+        @param mode: the mode to be used. Possible values are:
+
+          - C{ADJ_DIRECTED} - the graph will be directed and a matrix
+            element gives the number of edges between two vertex.
+          - C{ADJ_UNDIRECTED} - alias to C{ADJ_MAX} for convenience.
+          - C{ADJ_MAX}   - undirected graph will be created and the number of
+            edges between vertex M{i} and M{j} is M{max(A(i,j), A(j,i))}
+          - C{ADJ_MIN}   - like C{ADJ_MAX}, but with M{min(A(i,j), A(j,i))}
+          - C{ADJ_PLUS}  - like C{ADJ_MAX}, but with M{A(i,j) + A(j,i)}
+          - C{ADJ_UPPER} - undirected graph with the upper right triangle of
+            the matrix (including the diagonal)
+          - C{ADJ_LOWER} - undirected graph with the lower left triangle of
+            the matrix (including the diagonal)
+
+          These values can also be given as strings without the C{ADJ} prefix.
+
+        """
+        try:
+            import numpy as np
+        except ImportError:
+            np = None
+
+        try:
+            from scipy import sparse
+        except ImportError:
+            sparse = None
+
+        if (sparse is not None) and isinstance(matrix, sparse.spmatrix):
+            return _graph_from_sparse_matrix(klass, matrix, mode=mode)
+
+        if (np is not None) and isinstance(matrix, np.ndarray):
+            matrix = matrix.tolist()
+
+        return GraphBase.Adjacency(klass, matrix, mode=mode)
 
     def write_dimacs(self, f, source=None, target=None, capacity="capacity"):
         """Writes the graph in DIMACS format to the given file.

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -2107,7 +2107,7 @@ class Graph(GraphBase):
         return graph
 
     @classmethod
-    def Adjacency(klass, matrix, mode=ADJ_DIRECTED):
+    def Adjacency(klass, matrix, mode=ADJ_DIRECTED, *args, **kwargs):
         """Generates a graph from its adjacency matrix.
 
         @param matrix: the adjacency matrix. Possible types are:
@@ -2148,7 +2148,7 @@ class Graph(GraphBase):
         if (np is not None) and isinstance(matrix, np.ndarray):
             matrix = matrix.tolist()
 
-        return GraphBase.Adjacency(klass, matrix, mode=mode)
+        return klass._Adjacency(matrix, mode=mode)
 
     def write_dimacs(self, f, source=None, target=None, capacity="capacity"):
         """Writes the graph in DIMACS format to the given file.

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -2148,7 +2148,7 @@ class Graph(GraphBase):
         if (np is not None) and isinstance(matrix, np.ndarray):
             matrix = matrix.tolist()
 
-        return klass._Adjacency(matrix, mode=mode)
+        return super().Adjacency(matrix, mode=mode)
 
     def write_dimacs(self, f, source=None, target=None, capacity="capacity"):
         """Writes the graph in DIMACS format to the given file.

--- a/src/igraph/sparse_matrix.py
+++ b/src/igraph/sparse_matrix.py
@@ -4,7 +4,7 @@
 
 from __future__ import with_statement
 
-__all__ = ()
+__all__ = ['_graph_from_sparse_matrix']
 __docformat__ = "restructuredtext en"
 __license__ = u"""
 Copyright (C) 2021  igraph development team

--- a/src/igraph/sparse_matrix.py
+++ b/src/igraph/sparse_matrix.py
@@ -1,0 +1,109 @@
+# vim:ts=4:sw=4:sts=4:et
+# -*- coding: utf-8 -*-
+"""Implementation of union, disjoint union and intersection operators."""
+
+from __future__ import with_statement
+
+__all__ = ()
+__docformat__ = "restructuredtext en"
+__license__ = u"""
+Copyright (C) 2021  igraph development team
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA
+"""
+
+# pylint: disable-msg=W0401
+# W0401: wildcard import
+from igraph._igraph import *
+
+
+# Logic to get graph from scipy sparse matrix. This would be simple if there
+# weren't so many modes.
+def _graph_from_sparse_matrix(klass, matrix, mode=ADJ_DIRECTED):
+    # This function assumes there is scipy and the matrix is a scipy sparse
+    # matrix. The caller should make sure those conditions are met.
+    from scipy import sparse
+
+    modes = (
+        ADJ_DIRECTED,
+        ADJ_UNDIRECTED,
+        ADJ_MAX,
+        ADJ_MIN,
+        ADJ_PLUS,
+        ADJ_UPPER,
+        ADJ_LOWER,
+    )
+
+    if not isinstance(matrix, sparse.coo_matrix):
+        matrix = matrix.tocoo()
+
+    # Shorthand notation
+    m = matrix
+
+    if mode == ADJ_DIRECTED:
+        edges = sum(
+                ([(i, j)] * n for i, j, n in zip(m.row, m.col, m.data)),
+                [],
+                )
+        return klass(
+                edges=edges, directed=True,
+            )
+
+    if mode == ADJ_UNDIRECTED:
+        mode = ADJ_MAX
+
+    if mode in (ADJ_MAX, ADJ_MIN, ADJ_PLUS):
+        fun_dict = {
+                ADJ_MAX: max,
+                ADJ_MIN: min,
+                ADJ_PLUS: lambda *x: sum(x),
+        }
+        fun = fun_dict[mode]
+        nedges = {}
+        for i, j, n in zip(m.row, m.col, m.data):
+            # Fist time this pair of vertices
+            if (j, i) not in nedges:
+                nedges[(i, j)] = n
+            else:
+                nedges[(j, i)] = fun(nedges[(j, i)], n)
+
+        edges = sum(
+                ([e] * n for e, n in nedges.items()),
+                [],
+                )
+        return klass(
+                edges=edges, directed=False,
+            )
+
+    if mode == ADJ_UPPER:
+        edges = sum(
+                ([(i, j)] * n for i, j, n in zip(m.row, m.col, m.data) if j >= i),
+                [],
+                )
+        return klass(
+                edges=edges, directed=True,
+            )
+
+    if mode == ADJ_LOWER:
+        edges = sum(
+                ([(i, j)] * n for i, j, n in zip(m.row, m.col, m.data) if j <= i),
+                [],
+                )
+        return klass(
+                edges=edges, directed=True,
+            )
+
+    raise ValueError('mode should be one of ' + ' '.join(map(str, modes)))

--- a/src/igraph/sparse_matrix.py
+++ b/src/igraph/sparse_matrix.py
@@ -1,10 +1,10 @@
 # vim:ts=4:sw=4:sts=4:et
 # -*- coding: utf-8 -*-
-"""Implementation of union, disjoint union and intersection operators."""
+"""Implementation of Python-level sparse matrix operations."""
 
 from __future__ import with_statement
 
-__all__ = ['_graph_from_sparse_matrix']
+__all__ = ()
 __docformat__ = "restructuredtext en"
 __license__ = u"""
 Copyright (C) 2021  igraph development team
@@ -25,14 +25,22 @@ Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301 USA
 """
 
-# pylint: disable-msg=W0401
-# W0401: wildcard import
-from igraph._igraph import *
+from operator import add
+from igraph._igraph import (
+    ADJ_DIRECTED,
+    ADJ_UNDIRECTED,
+    ADJ_MAX,
+    ADJ_MIN,
+    ADJ_PLUS,
+    ADJ_UPPER,
+    ADJ_LOWER,
+)
 
 
 # Logic to get graph from scipy sparse matrix. This would be simple if there
 # weren't so many modes.
 def _graph_from_sparse_matrix(klass, matrix, mode=ADJ_DIRECTED):
+    '''Construct graph from sparse matrix, unweighted'''
     # This function assumes there is scipy and the matrix is a scipy sparse
     # matrix. The caller should make sure those conditions are met.
     from scipy import sparse
@@ -53,23 +61,20 @@ def _graph_from_sparse_matrix(klass, matrix, mode=ADJ_DIRECTED):
     # Shorthand notation
     m = matrix
 
-    if mode == ADJ_DIRECTED:
-        edges = sum(
-                ([(i, j)] * n for i, j, n in zip(m.row, m.col, m.data)),
-                [],
-                )
-        return klass(
-                edges=edges, directed=True,
-            )
-
     if mode == ADJ_UNDIRECTED:
         mode = ADJ_MAX
 
-    if mode in (ADJ_MAX, ADJ_MIN, ADJ_PLUS):
+    if mode == ADJ_DIRECTED:
+        edges = sum(
+            ([(i, j)] * n for i, j, n in zip(m.row, m.col, m.data)),
+            [],
+        )
+
+    elif mode in (ADJ_MAX, ADJ_MIN, ADJ_PLUS):
         fun_dict = {
-                ADJ_MAX: max,
-                ADJ_MIN: min,
-                ADJ_PLUS: lambda *x: sum(x),
+            ADJ_MAX: max,
+            ADJ_MIN: min,
+            ADJ_PLUS: add,
         }
         fun = fun_dict[mode]
         nedges = {}
@@ -81,29 +86,100 @@ def _graph_from_sparse_matrix(klass, matrix, mode=ADJ_DIRECTED):
                 nedges[(j, i)] = fun(nedges[(j, i)], n)
 
         edges = sum(
-                ([e] * n for e, n in nedges.items()),
-                [],
-                )
-        return klass(
-                edges=edges, directed=False,
-            )
+            ([e] * n for e, n in nedges.items()),
+            [],
+        )
 
-    if mode == ADJ_UPPER:
+    elif mode == ADJ_UPPER:
         edges = sum(
-                ([(i, j)] * n for i, j, n in zip(m.row, m.col, m.data) if j >= i),
-                [],
-                )
-        return klass(
-                edges=edges, directed=True,
-            )
+            ([(i, j)] * n for i, j, n in zip(m.row, m.col, m.data) if j >= i),
+            [],
+        )
 
-    if mode == ADJ_LOWER:
+    elif mode == ADJ_LOWER:
         edges = sum(
-                ([(i, j)] * n for i, j, n in zip(m.row, m.col, m.data) if j <= i),
-                [],
-                )
-        return klass(
-                edges=edges, directed=True,
-            )
+            ([(i, j)] * n for i, j, n in zip(m.row, m.col, m.data) if j <= i),
+            [],
+        )
 
-    raise ValueError('mode should be one of ' + ' '.join(map(str, modes)))
+    else:
+        raise ValueError("mode should be one of " + " ".join(map(str, modes)))
+
+    return klass(
+        edges=edges,
+        directed=mode == ADJ_DIRECTED,
+    )
+
+
+def _graph_from_weighted_sparse_matrix(klass, matrix, mode=ADJ_DIRECTED, attr='weight'):
+    '''Construct graph from sparse matrix, weighted
+
+    NOTE: Of course, you cannot emcompass a fully general weighted multigraph
+    with a single adjacency matrix, so we don't try to do it here either.
+    '''
+    # This function assumes there is scipy and the matrix is a scipy sparse
+    # matrix. The caller should make sure those conditions are met.
+    from scipy import sparse
+
+    modes = (
+        ADJ_DIRECTED,
+        ADJ_UNDIRECTED,
+        ADJ_MAX,
+        ADJ_MIN,
+        ADJ_PLUS,
+        ADJ_UPPER,
+        ADJ_LOWER,
+    )
+
+    if not isinstance(matrix, sparse.coo_matrix):
+        matrix = matrix.tocoo()
+
+    # Shorthand notation
+    m = matrix
+
+    if mode == ADJ_UNDIRECTED:
+        mode = ADJ_MAX
+
+    if mode == ADJ_DIRECTED:
+        edges = list(zip(m.row, m.col))
+        weights = list(m.data)
+
+    elif mode in (ADJ_MAX, ADJ_MIN, ADJ_PLUS):
+        fun_dict = {
+            ADJ_MAX: max,
+            ADJ_MIN: min,
+            ADJ_PLUS: add,
+        }
+        fun = fun_dict[mode]
+        nedges = {}
+        for i, j, n in zip(m.row, m.col, m.data):
+            # Fist time this pair of vertices
+            if (j, i) not in nedges:
+                nedges[(i, j)] = n
+            else:
+                nedges[(j, i)] = fun(nedges[(j, i)], n)
+
+        edges, weights = zip(*nedges.items())
+
+    elif mode == ADJ_UPPER:
+        edges, weights = [], []
+        for i, j, n in zip(m.row, m.col, m.data):
+            if j >= i:
+                edges.append((i, j))
+                weights.append(n)
+
+    elif mode == ADJ_LOWER:
+        edges, weights = [], []
+        for i, j, n in zip(m.row, m.col, m.data):
+            if j <= i:
+                edges.append((i, j))
+                weights.append(n)
+
+    else:
+        raise ValueError("mode should be one of " + " ".join(map(str, modes)))
+
+    return klass(
+        edges=edges,
+        directed=mode == ADJ_DIRECTED,
+        edge_attrs={attr: weights},
+    )

--- a/src/igraph/sparse_matrix.py
+++ b/src/igraph/sparse_matrix.py
@@ -40,7 +40,7 @@ from igraph._igraph import (
 # Logic to get graph from scipy sparse matrix. This would be simple if there
 # weren't so many modes.
 def _graph_from_sparse_matrix(klass, matrix, mode=ADJ_DIRECTED):
-    '''Construct graph from sparse matrix, unweighted'''
+    """Construct graph from sparse matrix, unweighted"""
     # This function assumes there is scipy and the matrix is a scipy sparse
     # matrix. The caller should make sure those conditions are met.
     from scipy import sparse
@@ -111,12 +111,12 @@ def _graph_from_sparse_matrix(klass, matrix, mode=ADJ_DIRECTED):
     )
 
 
-def _graph_from_weighted_sparse_matrix(klass, matrix, mode=ADJ_DIRECTED, attr='weight'):
-    '''Construct graph from sparse matrix, weighted
+def _graph_from_weighted_sparse_matrix(klass, matrix, mode=ADJ_DIRECTED, attr="weight"):
+    """Construct graph from sparse matrix, weighted
 
     NOTE: Of course, you cannot emcompass a fully general weighted multigraph
     with a single adjacency matrix, so we don't try to do it here either.
-    '''
+    """
     # This function assumes there is scipy and the matrix is a scipy sparse
     # matrix. The caller should make sure those conditions are met.
     from scipy import sparse


### PR DESCRIPTION
This tries to implement #357, i.e. generating a `Graph` object from a sparse scipy matrix, which is the de facto standard in Pythonlands for such cases.

The key is to bypass `GraphBase.Adjacency`, which dispatches to a C function expecting a dense matrix. Instead, I reproduce the logic of the various C-level functions depending on the mode (e.g. `igraph_i_adjacency_lower`, all in the `igraph` project, `src/constructors.c`).

A few notes:
- graceful try to import scipy to check if the matrix is sparse
- added a case for (dense) `numpy` 2D `ndarrays` (which include `numpy.matrix` object) with a similar graceful import
- outsourced the sparse case to a private `_` function in a new `sparse_matrix` module to avoid cluttering the main module. Happy to discuss namespacing or alternatives
- the details of the logic use a more Pythonic syntax than their C counterparts, while trying to be somewhat efficient. No efforts were undertaken to actually optimize these operations, and I wouldn't mind getting rid of some black magic if you don't like it (sums over conditional lazy comprehensions).

Funnily enough, the concrete case that prompted me to make this PR is a *weighted* adjacency sparse matrix... so I would like to implement the weighted case as well, any suggestions how to call the class method in that case? Perhaps just `graph.AdjacencyWeighted`?

No tests written yet.

edit: Oh I just saw `Weighted_Adjacency`.