### PR TITLE
Fix links to the documentation in the tutorial

### DIFF
--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -1050,6 +1050,6 @@ of the `Graph class`_. Should you get stuck, try asking in our
 `Discourse group`_ first - maybe there is someone out there who can help you
 out immediately.
 
-.. _API documentation: https://igraph.org/python/doc/igraph-module.html
-.. _Graph class: https://igraph.org/python/doc/igraph.Graph-class.html
+.. _API documentation: https://igraph.org/python/doc/api/index.html
+.. _Graph class: https://igraph.org/python/doc/api/igraph.Graph.html
 .. _Discourse group: https://igraph.discourse.group


### PR DESCRIPTION
The links to the python-igraph documentation at the end of the tutorial were broken.