### PR TITLE
Workaround in setup.py for installing with CMake >= 3.19.8 on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -264,6 +264,7 @@ class IgraphCCoreCMakeBuilder(IgraphCCoreBuilder):
             return False
 
         print("Running build...")
+        # We are _not_ using a parallel build; this is intentional, see igraph/igraph#1755
         retcode = subprocess.call(
             [cmake, "--build", ".", "--config", "Release"]
         )

--- a/setup.py
+++ b/setup.py
@@ -265,13 +265,13 @@ class IgraphCCoreCMakeBuilder(IgraphCCoreBuilder):
 
         print("Running build...")
         retcode = subprocess.call(
-            [cmake, "--build", ".", "--parallel", "--config", "Release"]
+            [cmake, "--build", ".", "--config", "Release"]
         )
         if retcode:
             return False
 
         print("Installing build...")
-        retcode = subprocess.call([cmake, "--install", ".", "--prefix", str(install_folder)])
+        retcode = subprocess.call([cmake, "--install", ".", "--prefix", str(install_folder), "--config", "Release"])
         if retcode:
             return False
 


### PR DESCRIPTION
This addresses the problem that was noted in https://github.com/igraph/igraph/issues/1755. In particular, this removes the `--parallel` option which causes the problem. Additionally, it also explicitly installs the Release configuration.