### PR TITLE
Realize degree sequence

### DIFF
--- a/doc/source/generation.rst
+++ b/doc/source/generation.rst
@@ -170,5 +170,6 @@ Finally, there are some ways of generating graphs that are not covered by the pr
  - De Bruijn graphs :meth:`Graph.De_Bruijn`
  - Lederberg-Coxeter-Frucht graphs :meth:`Graph.LCF`
  - graphs with a specified isomorphism class :meth:`Graph.Isoclass`
+ - graphs with a specified degree sequence :meth:`Graph.Realize_Degree_Sequence`
                      
 .. _API documentation: https://igraph.org/python/doc/igraph-module.html

--- a/src/_igraph/convert.c
+++ b/src/_igraph/convert.c
@@ -141,7 +141,7 @@ int igraphmodule_PyObject_to_enum(PyObject *o,
 int igraphmodule_PyObject_to_enum_strict(PyObject *o,
   igraphmodule_enum_translation_table_entry_t* table,
   int *result) {
-    char *s;
+    char *s, *s2;
 
     if (o == 0 || o == Py_None)
       return 0;
@@ -152,7 +152,9 @@ int igraphmodule_PyObject_to_enum_strict(PyObject *o,
         PyErr_SetString(PyExc_TypeError, "int, long or string expected");
         return -1;
     }
-    /* Do NOT convert string to lowercase */
+    /* Convert string to lowercase */
+    for (s2=s; *s2; s2++)
+      *s2 = tolower(*s2);
     /* Search for exact matches */
     while (table->name != 0) {
         if (strcmp(s, table->name) == 0) {

--- a/src/_igraph/convert.c
+++ b/src/_igraph/convert.c
@@ -3025,3 +3025,37 @@ int igraphmodule_PyObject_to_pagerank_algo_t(PyObject *o, igraph_pagerank_algo_t
 
   return igraphmodule_PyObject_to_enum(o, pagerank_algo_tt, (int*)result);
 }
+
+/**
+ * \ingroup python_interface_conversion
+ * \brief Converts a Python object to an igraph \c igraph_edge_type_sw_t
+ */
+int igraphmodule_PyObject_to_edge_type_sw_t(PyObject *o, igraph_edge_type_sw_t *result) {
+  static igraphmodule_enum_translation_table_entry_t edge_type_sw_tt[] = {
+        {"simple_sw", IGRAPH_SIMPLE_SW},
+        {"loops_sw", IGRAPH_LOOPS_SW},
+        {"multi_sw", IGRAPH_MULTI_SW},
+        {"both_sw", IGRAPH_LOOPS_SW | IGRAPH_MULTI_SW},
+        {0,0}
+    };
+
+  return igraphmodule_PyObject_to_enum(o, edge_type_sw_tt, (int*)result);
+}
+
+/**
+ * \ingroup python_interface_conversion
+ * \brief Converts a Python object to an igraph \c igraph_realize_degseq_t
+ */
+int igraphmodule_PyObject_to_realize_degseq_t(PyObject *o, igraph_realize_degseq_t *result) {
+  static igraphmodule_enum_translation_table_entry_t realize_degseq_tt[] = {
+        {"smallest", IGRAPH_REALIZE_DEGSEQ_SMALLEST},
+        {"largest", IGRAPH_REALIZE_DEGSEQ_LARGEST},
+        {"index", IGRAPH_REALIZE_DEGSEQ_INDEX},
+        {0,0}
+    };
+
+  return igraphmodule_PyObject_to_enum(o, realize_degseq_tt, (int*)result);
+}
+
+
+

--- a/src/_igraph/convert.h
+++ b/src/_igraph/convert.h
@@ -63,6 +63,8 @@ int igraphmodule_PyObject_to_get_adjacency_t(PyObject *o, igraph_get_adjacency_t
 int igraphmodule_PyObject_to_layout_grid_t(PyObject *o, igraph_layout_grid_t *result);
 int igraphmodule_PyObject_to_neimode_t(PyObject *o, igraph_neimode_t *result);
 int igraphmodule_PyObject_to_pagerank_algo_t(PyObject *o, igraph_pagerank_algo_t *result);
+int igraphmodule_PyObject_to_edge_type_sw_t(PyObject *o, igraph_edge_type_sw_t *result);
+int igraphmodule_PyObject_to_realize_degseq_t(PyObject *o, igraph_realize_degseq_t *result);
 int igraphmodule_PyObject_to_random_walk_stuck_t(PyObject *o, igraph_random_walk_stuck_t *result);
 int igraphmodule_PyObject_to_reciprocity_t(PyObject *o, igraph_reciprocity_t *result);
 int igraphmodule_PyObject_to_rewiring_t(PyObject *o, igraph_rewiring_t *result);

--- a/src/_igraph/convert.h
+++ b/src/_igraph/convert.h
@@ -47,6 +47,8 @@ int PyLong_AsInt(PyObject* obj, int* result);
 
 int igraphmodule_PyObject_to_enum(PyObject *o,
   igraphmodule_enum_translation_table_entry_t *table, int *result);
+int igraphmodule_PyObject_to_enum_strict(PyObject *o,
+  igraphmodule_enum_translation_table_entry_t *table, int *result);
 int igraphmodule_PyObject_to_add_weights_t(PyObject *o, igraph_add_weights_t *result);
 int igraphmodule_PyObject_to_adjacency_t(PyObject *o, igraph_adjacency_t *result);
 int igraphmodule_PyObject_to_attribute_combination_type_t(PyObject* o,

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -2804,7 +2804,6 @@ PyObject *igraphmodule_Graph_Realize_Degree_Sequence(PyTypeObject *type,
   igraph_edge_type_sw_t allowed_edge_types;
   igraph_realize_degseq_t method;
   PyObject *outdeg_o, *indeg_o, *edge_types_o, *method_o;
-  PyObject *repr;
   igraphmodule_GraphObject *self;
   igraph_t g;
 
@@ -2814,36 +2813,12 @@ PyObject *igraphmodule_Graph_Realize_Degree_Sequence(PyTypeObject *type,
     return NULL;
 
   /* allowed edge types */
-  repr = PyObject_Str(edge_types_o);
-  if (PyUnicode_CompareWithASCIIString(repr, "simple_sw") == 0)
-    allowed_edge_types = IGRAPH_SIMPLE_SW;
-  else if (PyUnicode_CompareWithASCIIString(repr, "loops_sw") == 0)
-    allowed_edge_types = IGRAPH_LOOPS_SW;
-  else if (PyUnicode_CompareWithASCIIString(repr, "multi_sw") == 0)
-    allowed_edge_types = IGRAPH_MULTI_SW;
-  else if (PyUnicode_CompareWithASCIIString(repr, "both_sw") == 0)
-    allowed_edge_types = IGRAPH_LOOPS_SW | IGRAPH_MULTI_SW;
-  else {
-    Py_XDECREF(repr);
-    PyErr_SetString(PyExc_ValueError, "allowed_edge_types must be 'simple_sw' or 'multi_sw' (undirected only).");
-      return NULL;
-  }
-  Py_XDECREF(repr);
+  if (igraphmodule_PyObject_to_edge_type_sw_t(edge_types_o, &allowed_edge_types))
+    return NULL;
 
   /* methods */
-  repr = PyObject_Str(method_o);
-  if (PyUnicode_CompareWithASCIIString(repr, "smallest") == 0)
-    method = IGRAPH_REALIZE_DEGSEQ_SMALLEST;
-  else if (PyUnicode_CompareWithASCIIString(repr, "largest") == 0)
-    method = IGRAPH_REALIZE_DEGSEQ_LARGEST;
-  else if (PyUnicode_CompareWithASCIIString(repr, "index") == 0)
-    method = IGRAPH_REALIZE_DEGSEQ_INDEX;
-  else {
-    Py_XDECREF(repr);
-    PyErr_SetString(PyExc_ValueError, "method must be 'smallest', 'largest', or 'index'");
+  if (igraphmodule_PyObject_to_realize_degseq_t(method_o, &method))
     return NULL;
-  }
-  Py_XDECREF(repr);
 
   /* Outdegree vector */
   if (igraphmodule_PyObject_to_vector_t(outdeg_o, &outdeg, 0))

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -2817,8 +2817,12 @@ PyObject *igraphmodule_Graph_Realize_Degree_Sequence(PyTypeObject *type,
   repr = PyObject_Str(edge_types_o);
   if (PyUnicode_CompareWithASCIIString(repr, "simple_sw") == 0)
     allowed_edge_types = IGRAPH_SIMPLE_SW;
+  else if (PyUnicode_CompareWithASCIIString(repr, "loops_sw") == 0)
+    allowed_edge_types = IGRAPH_LOOPS_SW;
   else if (PyUnicode_CompareWithASCIIString(repr, "multi_sw") == 0)
     allowed_edge_types = IGRAPH_MULTI_SW;
+  else if (PyUnicode_CompareWithASCIIString(repr, "both_sw") == 0)
+    allowed_edge_types = IGRAPH_LOOPS_SW | IGRAPH_MULTI_SW;
   else {
     Py_XDECREF(repr);
     PyErr_SetString(PyExc_ValueError, "allowed_edge_types must be 'simple_sw' or 'multi_sw' (undirected only).");
@@ -12695,11 +12699,16 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
     "or the out-degree sequence of a directed graph.\n"
     "@param indeg: None to generate an undirected graph, the in-degree sequence "
     "to generate a directed graph.\n"
-    "@param allowed_edge_types: TODO!\n"
+    "@param allowed_edge_types: for directed graphs, only 'simple_sw' is currently \n"
+    "implemented. Possible values for undirected graphs are\n"
+    " - 'simple_sw: simple graphs (no self-loops, no multi-edges)\n"
+    " - 'loops_sw': single self-loops allowed, but not multi-edges \n"
+    " - 'multi_sw': multi-edges allowed, but not self-loops \n"
+    " - 'both_sw': multi-edges and self-loops allowed \n"
     "@param method: possible values are\n"
-    " - REALIZE_DEGSEQ_SMALLEST: The vertex with smallest remaining degree first.\n"
-    " - REALIZE_DEGSEQ_LARGEST: The vertex with the largest remaining degree first.\n"
-    " - REALIZE_DEGSEQ_INDEX: The vertices are selected in order of their index.\n"
+    " - 'smallest': The vertex with smallest remaining degree first.\n"
+    " - 'largest': The vertex with the largest remaining degree first.\n"
+    " - 'index': The vertices are selected in order of their index.\n"
   },
 
   // interface to igraph_ring

--- a/src/_igraph/graphobject.h
+++ b/src/_igraph/graphobject.h
@@ -92,6 +92,7 @@ PyObject* igraphmodule_Graph_Growing_Random(PyTypeObject *type, PyObject *args, 
 PyObject* igraphmodule_Graph_Isoclass(PyTypeObject *type, PyObject *args, PyObject *kwds);
 PyObject* igraphmodule_Graph_Lattice(PyTypeObject *type, PyObject *args, PyObject *kwds);
 PyObject* igraphmodule_Graph_LCF(PyTypeObject *type, PyObject *args, PyObject *kwds);
+PyObject* igraphmodule_Graph_Realize_Degree_Sequence(PyTypeObject *type, PyObject *args, PyObject *kwds);
 PyObject* igraphmodule_Graph_Preference(PyTypeObject *type, PyObject *args, PyObject *kwds);
 PyObject* igraphmodule_Graph_Recent_Degree(PyTypeObject *type, PyObject *args, PyObject *kwds);
 PyObject* igraphmodule_Graph_Ring(PyTypeObject *type, PyObject *args, PyObject *kwds);

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -134,6 +134,33 @@ class GeneratorTests(unittest.TestCase):
         self.assertTrue(g1.isomorphic(g2))
         self.assertRaises(InternalError, Graph.LCF, 12, (5, -5), -3)
 
+    def testRealizeDegreeSequence(self):
+        g = Graph.Realize_Degree_Sequence(
+            [1, 1], None, "simple_sw", "smallest",
+        )
+        self.assertFalse(g.is_directed())
+
+        g = Graph.Realize_Degree_Sequence(
+            [1, 1], None, "multi_sw", "index",
+        )
+        self.assertFalse(g.is_directed())
+
+        g = Graph.Realize_Degree_Sequence(
+            [1, 1], [1, 1], "simple_sw", "largest",
+        )
+        self.assertTrue(g.is_directed())
+
+        # Not implemented, should fail
+        self.assertRaises(NotImplementedError, Graph.Realize_Degree_Sequence,
+                [1, 1], [1, 1], "multi_sw", "largest")
+
+        self.assertRaises(ValueError, Graph.Realize_Degree_Sequence,
+                [1, 1], [1, 1], "should_fail", "index")
+        self.assertRaises(ValueError, Graph.Realize_Degree_Sequence,
+                [1, 1], [1, 1], "multi_sw", "should_fail")
+
+
+
     def testKautz(self):
         g = Graph.Kautz(2, 2)
         deg_in = g.degree(mode=IN)

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -135,8 +135,9 @@ class GeneratorTests(unittest.TestCase):
         self.assertRaises(InternalError, Graph.LCF, 12, (5, -5), -3)
 
     def testRealizeDegreeSequence(self):
+        # Test case insensitivity of options too
         g = Graph.Realize_Degree_Sequence(
-            [1, 1], None, "simple_sw", "smallest",
+            [1, 1], None, "simple_SW", "smallest",
         )
         self.assertFalse(g.is_directed())
 

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -140,6 +140,15 @@ class GeneratorTests(unittest.TestCase):
         )
         self.assertFalse(g.is_directed())
 
+        # Not implemented, should fail
+        self.assertRaises(NotImplementedError, Graph.Realize_Degree_Sequence,
+                [1, 1], None, "loops_sw", "largest")
+
+        g = Graph.Realize_Degree_Sequence(
+            [1, 1], None, "both_sw", "largest",
+        )
+        self.assertFalse(g.is_directed())
+
         g = Graph.Realize_Degree_Sequence(
             [1, 1], None, "multi_sw", "index",
         )


### PR DESCRIPTION
Trying to fix #316 

This also relates to #385. In that PR, I added two constants to the global API of `python-igraph`, mimicking what happens at the C level. In this case, I used strings as options in Python, which keeps the API cleaner. I think both PR should use the same approach, but I wanted you guys to see the options.

I'd prefer to use strings as in here, any other opinions @ntamas @szhorvat @vtraag ?