### PR TITLE
Track vertex and edge order and multiedge key to/from networkx

### DIFF
--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -1937,7 +1937,7 @@ class Graph(GraphBase):
 
         Vertex names will be converted to "_nx_name" attribute and the vertices
         will get new ids from 0 up (as standard in igraph). In case of
-        multigraphs, each edge will have an "_nx_multiedgekey" attribute, to
+        multigraphs, each edge will have an "_nx_multiedge_key" attribute, to
         distinguish edges that connect the same two vertices.
 
         @param g: networkx Graph or DiGraph

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -1955,9 +1955,14 @@ class Graph(GraphBase):
 
         # Dictionary connecting networkx hashables with igraph indices
         if len(g) and '_igraph_index' in g.nodes[0]:
+            # Collect _igraph_index and fill gaps
+            idx = [x['_igraph_index'] for v, x in g.nodes.data()]
+            idx.sort()
+            idx_dict = {x: i for i, x in enumerate(idx)}
+
             vd = {}
             for v, datum in g.nodes.data():
-                vd[v] = datum['_igraph_index']
+                vd[v] = idx_dict[datum['_igraph_index']]
         else:
             vd = {v: i for i, v in enumerate(vnames)}
 

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -551,8 +551,14 @@ class ForeignTests(unittest.TestCase):
 
         # Test attributes
         self.assertEqual(g.attributes(), g2.attributes())
-        self.assertEqual(sorted(["vattr", "_nx_name"]), sorted(g2.vertex_attributes()))
-        self.assertEqual(g.edge_attributes(), g2.edge_attributes())
+        self.assertEqual(
+                sorted(["vattr", "_nx_name"]),
+                sorted(g2.vertex_attributes()),
+                )
+        self.assertEqual(
+                sorted(["eattr", "_nx_multiedge_key"]),
+                sorted(g2.edge_attributes()),
+                )
         # Testing parallel edges is a bit more tricky
         edge2_found = set()
         for edge in g.es:


### PR DESCRIPTION
Improve conversions to/from networkx by using hidden vertex/edge attributes:

- `_nx_name` was already there: it stores the hashable used to identify the vertex in `networkx` after converting to `igraph`
- `_nx_multiedge_key` keeps track of `networkx`'s edge key, which is used to distinguish multiedges
- `_igraph_index` is now set when exporting to `networkx` to remember the order of vertices/edges in igraph (`networkx` does not have a strictly enforced order)

The first two attributes are checked on the way back from `igraph` into `networkx` to set proper vertex names and edge keys, respectively. The last attribute is used on the way back from `networkx` to `igraph` to sort edges according to their original order, or whatever comes closest to that.

Of course, manual manipulations of these attributes by the users can mess up the bookkeeping. That's ok I think, they know what they're getting themselves into since the attribute names start with _ which in Python is lingo for "don't touch!".

An interesting case is if e.g. the user exports an `igraph` graph to `networkx`, thins it out by deleting a few edges, and then converts back. Then the order of edges is maintained except the missing edges are skipped, of course.

@szhorvat @ntamas would be great if you could take a look and let me know your thoughts. I've had to adapt CI tests a little, which highlighted some bugs that are now fixed.

edit: I found one more bug. ig -> nx -> delete a vertex -> ig will probably error out. Fixed now.

edit2: There must be a bug when ig -> nx -> add vertices/edges -> ig because the newly added objects cannot have an `_igraph_index`. They should be defaulted to a (random?) increasing `_igraph_index` I guess, but that might or might not be deterministic since they were generated in the context of a nondeterministic library...