### PR TITLE
add doc for font-family

### DIFF
--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -824,6 +824,8 @@ Attribute name  Keyword argument       Purpose
 =============== ====================== ==========================================
 ``color``       ``vertex_color``       Color of the vertex
 --------------- ---------------------- ------------------------------------------
+``font``        ``vertex_font``        Font family of the vertex
+--------------- ---------------------- ------------------------------------------
 ``label``       ``vertex_label``       Label of the vertex
 --------------- ---------------------- ------------------------------------------
 ``label_angle`` ``vertex_label_angle`` The placement of the vertex label on the
@@ -870,6 +872,8 @@ Attribute name  Keyword argument       Purpose
                                        make multiple edges visible. See also the
                                        ``autocurve`` keyword argument to
                                        :func:`plot`.
+--------------- ---------------------- ------------------------------------------
+``font``        ``edge_font``          Font family of the edge
 --------------- ---------------------- ------------------------------------------
 ``arrow_size``  ``edge_arrow_size``    Size (length) of the arrowhead on the edge
                                        if the graph is directed, relative to 15


### PR DESCRIPTION
It seems no documentation on the customization of font-family, although this feature has been implemented in https://github.com/igraph/python-igraph/pull/32/commits
Without such documentation, until I came across an old question posted in https://stackoverflow.com/questions/24231430/how-to-use-custom-typeface-for-vertex-labels-in-python-igraph, and then checked the related source code, I got how to specify the font family.