### PR TITLE
fix: handle text wrapping if width=0

### DIFF
--- a/src/igraph/drawing/text.py
+++ b/src/igraph/drawing/text.py
@@ -107,11 +107,11 @@ class TextDrawer(AbstractCairoDrawer):
 
         line_height = ctx.font_extents()[2]
 
-        if wrap:
-            if width and width > 0:
-                iterlines = self._iterlines_wrapped(width)
-            else:
-                warn("ignoring wrap=True as no width was specified")
+        if wrap and width and width > 0:
+            iterlines = self._iterlines_wrapped(width)
+        elif wrap:
+            warn("ignoring wrap=True as no width was specified")
+            iterlines = self._iterlines()
         else:
             iterlines = self._iterlines()
 


### PR DESCRIPTION
Current behavior:

```python
g = ig.Graph.Erdos_Renyi(5, m=4)
ig.plot(g, wrap_labels=True, vertex_size=[5, 5, 5, 5, 0], vertex_label=list('abcde'))
# -> UnboundLocalError: local variable 'iterlines' referenced before assignment
```

This fix makes sure that `iterlines` is properly set even if a vertex has size 0.