### PR TITLE
fix: handle PathLike in Graph.write and Graph.Read

### DIFF
--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -2915,6 +2915,8 @@ class Graph(GraphBase):
         @raises IOError: if the file format can't be identified and
           none was given.
         """
+        if isinstance(f, os.PathLike):
+            f = str(f)
         if format is None:
             format = cls._identify_format(f)
         try:
@@ -2972,6 +2974,8 @@ class Graph(GraphBase):
         @raises IOError: if the file format can't be identified and
           none was given.
         """
+        if isinstance(f, os.PathLike):
+            f = str(f)
         if format is None:
             format = self._identify_format(f)
         try:


### PR DESCRIPTION
With this fix, the following is possible:

```python
from pathlib import Path
import igraph as ig

outdir = Path("/tmp")
g = ig.Graph.Famous("zachary")

g.write(outdir / "zachary.gml")
```

os.PathLike was introduced in Python 3.6, and given igraph's aim of
supporting the three most recent minor versions of Python 3, depending
on it should not be an issue.

This is a minimal fix, which simply turns PathLike objects into their
string representation and otherwise keeps existing behavior. A more
ambitious fix would be to rewrite how files and paths are handled using
pathlib.Path.