### PR TITLE
fix: recognize SVG format from file extension

### DIFF
--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -2842,23 +2842,24 @@ class Graph(GraphBase):
                 return "graphmlz"
 
         if ext in [
-            ".graphml",
-            ".graphmlz",
-            ".lgl",
-            ".ncol",
-            ".pajek",
-            ".gml",
             ".dimacs",
+            ".dl",
+            ".dot",
+            ".edge",
             ".edgelist",
             ".edges",
-            ".edge",
+            ".gml",
+            ".graphml",
+            ".graphmlz",
+            ".gw",
+            ".lgl",
+            ".lgr",
+            ".ncol",
             ".net",
+            ".pajek",
             ".pickle",
             ".picklez",
-            ".dot",
-            ".gw",
-            ".lgr",
-            ".dl",
+            ".svg",
         ]:
             return ext[1:]
 


### PR DESCRIPTION
The list in `Graph._identify_format` omitted the .svg extension. I added it and alphabetized the list to make it easier to spot other omissions.