### PR TITLE
Update documentation on installation of python-igraph

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -39,7 +39,7 @@ that you install it from the `Python Package Index
 and macOS. We aim to provide binary packages for the three latest minor versions of Python 3.x.
 
 To install |python-igraph| globally, use the following command (you probably need
-administrator/root priviledges)::
+administrator/root privileges)::
 
   $ pip install python-igraph
 


### PR DESCRIPTION
A user [reported](https://igraph.discourse.group/t/msys2-python-windows-instructions-incomplete-cmake-nor-build-c-core-work/898/13?u=vtraag) in the forum that after installation of `python-igraph` using `conda` it could be checked that it was properly installed by doing

```python
import igraph.tests
igraph.test.run_tests()
```

However, this has never worked like that, at least not since `python-igraph` 0.8.0 (as far as I could check).

This PR fixes that issue.

There are some other issues that we should also address:

- [x] The section on installing `python-igraph` from PyPI also mentions running the tests using `python -m unittest discover`. @ntamas, if I'm correct, this does not work, right? As far as I can see, no test files are included in any of the binary wheels at least, only in the source tarball.
- [x] All of the commands (i.e. leading with `$`) are being rendered in normal font. This also messes up some commands, as it renders `--` as an em-dash `–`. I think the code blocks should be introduced with double colons instead of a single colon?
- [x] Some links are incorrectly formatted, most likely because of line-breaks in the `.rst`.
- [x] Pieces of code also seem to be incorrectly rended, and should be within double backticks, not single backticks I believe.

I can further correct these tomorrow.
