### PR TITLE
Fix docstrings for pydoctor

### DIFF
--- a/scripts/mkdoc.sh
+++ b/scripts/mkdoc.sh
@@ -26,6 +26,9 @@ fi
 
 PWD=`pwd`
 
+echo "Patch pydoctor until they fix it"
+$SCRIPTS_FOLDER/patch-pydoctor.sh ${ROOT_FOLDER} ${SCRIPTS_FOLDER}
+
 echo "Removing existing documentation..."
 rm -rf "${DOC_API_FOLDER}/html" "${DOC_API_FOLDER}/pdf"
 
@@ -37,9 +40,11 @@ rm -rf "${SITE_PACKAGES_DIR}"/python_igraph*.egg-link
 echo "Installing python-igraph in virtualenv..."
 rm -f dist/*.whl && .venv/bin/python setup.py bdist_wheel && .venv/bin/pip install --force-reinstall dist/*.whl
 
-IGRAPHDIR=`.venv/bin/python3 -c 'import igraph, os; print(os.path.dirname(igraph.__file__))'`
+echo "Patching modularized Graph methods"
+.venv/bin/python3 ${SCRIPTS_FOLDER}/patch_modularized_graph_methods.py
 
 echo "Generating HTML documentation..."
+IGRAPHDIR=`.venv/bin/python3 -c 'import igraph, os; print(os.path.dirname(igraph.__file__))'`
 "$PYDOCTOR" \
     --project-name "python-igraph" \
     --project-url "https://igraph.org/python" \

--- a/scripts/patch-pydoctor.sh
+++ b/scripts/patch-pydoctor.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Patches PyDoctor to make it suitable to build python-igraph's documentation
+# until our patches get upstreamed
+
+if [ "x$1" = x ]; then
+    echo "Usage: $0 ROOT_FOLDER PATCH_FOLDER"
+    exit 1
+fi
+
+set -e
+
+ROOT_FOLDER=$1
+PATCH_FOLDER=$(realpath $2)
+${ROOT_FOLDER}/.venv/bin/pip uninstall -y pydoctor
+${ROOT_FOLDER}/.venv/bin/pip install pydoctor==21.2.2
+PYDOCTOR_DIR=`.venv/bin/python -c 'import os,pydoctor;print(os.path.dirname(pydoctor.__file__))'`
+
+cd "${PYDOCTOR_DIR}"
+# patch is confirmed to work with pydoctor 21.2.2
+patch -r deleteme.rej -N -p2 <${PATCH_FOLDER}/pydoctor-21.2.2.patch 2>/dev/null
+rm -f deleteme.rej
+
+

--- a/scripts/patch_modularized_graph_methods.py
+++ b/scripts/patch_modularized_graph_methods.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import inspect
+
+import igraph
+
+
+# Get instance and classmethods
+g = igraph.Graph()
+methods = inspect.getmembers(g, predicate=inspect.ismethod)
+
+# Get the source code for each method and replace the method name
+# in the signature
+methodsources = {}
+for mname, method in methods:
+    source = inspect.getsourcelines(method)[0]
+    fname = source[0][source[0].find('def ') + 4: source[0].find('(')]
+    newsource = [source[0].replace(fname, mname)] + source[1:]
+    methodsources[mname] = newsource
+
+# Make .new file with replacements
+newmodule = igraph.__file__ + '.new'
+with open(newmodule, 'wt') as fout:
+    with open(igraph.__file__, 'rt') as f:
+        for line in f:
+            for mname in methodsources:
+                # Catch the methods, excluding factories (e.g. 3d layouts)
+                if (mname + ' = _' in line) and ('(' not in line):
+                    break
+            else:
+                fout.write(line)
+                continue
+
+            # Method found, substitute
+            fout.write('\n')
+            for mline in methodsources[mname]:
+                # Correct indentation
+                fout.write('    ' + mline)
+
+# Move the new file back
+with open(igraph.__file__, 'wt') as fout:
+    with open(newmodule, 'rt') as f:
+        fout.write(f.read())
+
+# Delete .new file
+os.remove(newmodule)

--- a/scripts/pydoctor-21.2.2.patch
+++ b/scripts/pydoctor-21.2.2.patch
@@ -1,0 +1,167 @@
+diff --git a/pydoctor/astbuilder.py b/pydoctor/astbuilder.py
+index 6b274c9..393ddab 100644
+--- a/pydoctor/astbuilder.py
++++ b/pydoctor/astbuilder.py
+@@ -188,7 +188,7 @@ class ModuleVistor(ast.NodeVisitor):
+             self.newAttr = None
+ 
+     def visit_Module(self, node: ast.Module) -> None:
+-        assert self.module.docstring is None
++        # assert self.module.docstring is None
+ 
+         self.builder.push(self.module, 0)
+         if len(node.body) > 0 and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Str):
+diff --git a/pydoctor/epydoc2stan.py b/pydoctor/epydoc2stan.py
+index 1b418ae..841c773 100644
+--- a/pydoctor/epydoc2stan.py
++++ b/pydoctor/epydoc2stan.py
+@@ -191,6 +191,11 @@ class _EpydocLinker(DocstringLinker):
+             target = src.resolveName(identifier)
+             if target is not None:
+                 return target
++            if isinstance(src, model.Class):
++                for base in src.allbases():
++                    target = base.resolveName(identifier)
++                    if target is not None:
++                        return target
+             src = src.parent
+ 
+         # Walk up the object tree again and see if 'identifier' refers to an
+@@ -528,7 +533,7 @@ class FieldHandler:
+ 
+     def handleUnknownField(self, field: Field) -> None:
+         name = field.tag
+-        field.report(f"Unknown field '{name}'" )
++        # field.report(f"Unknown field '{name}'" )
+         self.unknowns[name].append(FieldDesc(name=field.arg, body=field.format()))
+ 
+     def handle(self, field: Field) -> None:
+diff --git a/pydoctor/model.py b/pydoctor/model.py
+index d233639..a14a4df 100644
+--- a/pydoctor/model.py
++++ b/pydoctor/model.py
+@@ -14,7 +14,7 @@ import platform
+ import sys
+ import types
+ from enum import Enum
+-from inspect import Signature
++from inspect import signature, Signature
+ from optparse import Values
+ from pathlib import Path
+ from typing import (
+@@ -514,7 +514,8 @@ class Function(Inheritable):
+     is_async: bool
+     annotations: Mapping[str, Optional[ast.expr]]
+     decorators: Optional[Sequence[ast.expr]]
+-    signature: Signature
++    signature: Optional[Signature]
++    text_signature: str = ""
+ 
+     def setup(self) -> None:
+         super().setup()
+@@ -776,15 +777,24 @@ class System:
+ 
+     def _introspectThing(self, thing: object, parent: Documentable, parentMod: _ModuleT) -> None:
+         for k, v in thing.__dict__.items():
+-            if (isinstance(v, (types.BuiltinFunctionType, types.FunctionType))
++            # TODO(ntamas): MethodDescriptorType and ClassMethodDescriptorType are Python 3.7 only.
++            if (isinstance(v, (types.BuiltinFunctionType, types.FunctionType, types.MethodDescriptorType, types.ClassMethodDescriptorType))
+                     # In PyPy 7.3.1, functions from extensions are not
+                     # instances of the above abstract types.
+-                    or v.__class__.__name__ == 'builtin_function_or_method'):
++                    or (hasattr(v, "__class__") and v.__class__.__name__ == 'builtin_function_or_method')):
+                 f = self.Function(self, k, parent)
+                 f.parentMod = parentMod
+                 f.docstring = v.__doc__
+                 f.decorators = None
+-                f.signature = Signature()
++                try:
++                    f.signature = signature(v)
++                except Exception:
++                    f.text_signature = (getattr(v, "__text_signature__") or "") + " (INVALID)"
++                    f.signature = None
++                f.is_async = False
++                f.annotations = {
++                    name: None for name in (f.signature.parameters if f.signature else {})
++                }
+                 self.addObject(f)
+             elif isinstance(v, type):
+                 c = self.Class(self, k, parent)
+@@ -912,7 +922,8 @@ class System:
+             mod.state = ProcessingState.PROCESSED
+             head = self.processing_modules.pop()
+             assert head == mod.fullName()
+-        self.unprocessed_modules.remove(mod)
++        if mod in self.unprocessed_modules:
++            self.unprocessed_modules.remove(mod)
+         self.progress(
+             'process',
+             self.module_count - len(self.unprocessed_modules),
+diff --git a/pydoctor/templatewriter/pages/__init__.py b/pydoctor/templatewriter/pages/__init__.py
+index e5f4050..3d326b3 100644
+--- a/pydoctor/templatewriter/pages/__init__.py
++++ b/pydoctor/templatewriter/pages/__init__.py
+@@ -49,7 +49,7 @@ def format_decorators(obj: Union[model.Function, model.Attribute]) -> Iterator[A
+ 
+ def signature(function: model.Function) -> str:
+     """Return a nicely-formatted source-like function signature."""
+-    return str(function.signature)
++    return str(function.signature) if function.signature else function.text_signature or "(...)"
+ 
+ class DocGetter:
+     """L{epydoc2stan} bridge."""
+diff --git a/pydoctor/templates/common.html b/pydoctor/templates/common.html
+index e5f4050..3d326b3 100644
+--- a/pydoctor/templates/common.html
++++ b/pydoctor/templates/common.html
+@@ -63,7 +63,7 @@
+       </div>
+       <address>
+         <a href="index.html">API Documentation</a> for <t:slot name="project">Some
+-          Project</t:slot>, generated by <a href="https://github.com/twisted/pydoctor/">pydoctor</a> <t:slot name="version" /> at <t:slot name="buildtime">some time</t:slot>.
++          Project</t:slot>, generated by <a href="https://github.com/twisted/pydoctor/">pydoctor</a> <t:slot name="version" />.
+       </address>
+ 
+     </div>
+diff --git a/pydoctor/templatewriter/summary.py b/pydoctor/templatewriter/summary.py
+index e5f4050..3d326b3 100644
+--- a/pydoctor/templatewriter/summary.py
++++ b/pydoctor/templatewriter/summary.py
+@@ -22,7 +22,7 @@
+         return r
+     ul = tags.ul()
+     for m in sorted(contents, key=lambda m:m.fullName()):
+-        ul(moduleSummary(m, page_url))
++        ul(moduleSummary(m, page_url), "\n")
+     return r(ul)
+ 
+ def _lckey(x):
+@@ -45,6 +45,7 @@
+         r = []
+         for o in self.system.rootobjects:
+             r.append(moduleSummary(o, self.filename))
++            r.append("\n")
+         return tag.clear()(r)
+     @renderer
+     def heading(self, request, tag):
+@@ -105,7 +106,7 @@
+     if len(scs) > 0:
+         ul = tags.ul()
+         for sc in sorted(scs, key=_lckey):
+-            ul(subclassesFrom(hostsystem, sc, anchors, page_url))
++            ul(subclassesFrom(hostsystem, sc, anchors, page_url), "\n")
+         r(ul)
+     return r
+ 
+@@ -136,9 +137,10 @@
+                 if o:
+                     ul = tags.ul()
+                     for sc in sorted(o, key=_lckey):
+-                        ul(subclassesFrom(self.system, sc, anchors, self.filename))
++                        ul(subclassesFrom(self.system, sc, anchors, self.filename), "\n")
+                     item(ul)
+                 t(item)
++            t("\n")
+         return t
+ 
+     @renderer


### PR DESCRIPTION
I added a script that uses a little introspection to swap in the `Graph` methods into the virtual environment used for the documentation build.

I also copied the pydoctor patch into this repo since that's needed to run `scripts/mkdoc.sh` anyway.

@ntamas can you please take a look if this fixes the issue with the modularized methods? It's not super pretty but perhaps a decent enough band-aid until we migrate to code generation.