### PR TITLE
Shortest path function that returns a "shortest path tree" object usa…

### DIFF
--- a/src/igraph/dijkstra.py
+++ b/src/igraph/dijkstra.py
@@ -1,0 +1,43 @@
+import sys
+
+
+def closest_neighbor(graph, weights, from_vertex):
+	min_dist = sys.maxint
+	for v in range(len(graph.vs[from_vertex])):
+		dist = weights[from_vertex][graph.vs[from_vertex][v]]
+		if (dist < min_dist):
+			min_dist = dist
+	
+	return min_dist
+
+
+def igraph_shortest_path_dijkstra(graph, from_vertex, weights):
+	no_of_nodes = graph.vcount()
+	no_of_edges = graph.ecount()
+	
+	if (len(weights) != no_of_edges):
+		raise ValueError("Weight vector length does not match")
+	
+	if (no_of_edges > 0):
+		min_weight = weights.min()
+		if (min_weight < 0):
+			raise ValueError("Weight vector must be non-negative")
+		elif (min_weight == None):
+			raise ValueError("Weight vector must not contain NaN values")
+	
+	dist = [sys.maxint] * no_of_nodes
+	dist[from_vertex] = 0
+	short_path_included = [0] * no_of_nodes
+	
+	for v in range(no_of_nodes):
+		neighbor = closest_neighbor(graph, weights, from_vertex)
+		
+		short_path_included[neighbor] = True
+		
+		for vertex in range(no_of_nodes):
+			if weights[neighbor][vertex] > 0 and not short_path_included[vertex]:
+				if dist[vertex] > dist[neighbor] + weights[neighbor][vertex]:
+					dist[vertex] = dist[neighbor] + weights[neighbor][vertex]
+				
+	return dist
+	


### PR DESCRIPTION
Meeting request for quick path retreival #470

Use cases for the feature

The proposed object is a concise representation of the shortest path structure from a given source. It takes O(|V|) storage only. The full lists of paths takes O(|V| d) storage where d is the average distance from s.

This object may be used repeatedly to get the shortest paths to arbitrary other nodes, very efficiently. If a user need to compute shortest path from s to other nodes, but does not know which other nodes to take yet, they are likely to run a full single-source shortest path algorithm separate for each target node. This is inefficient—why don't we make it possible to store the gist of the result from a single run and re-use it?

This function will be especially useful when working with large graphs, where both computation time and storage requirements are a concern.

In some applications, the shortest path tree itself may be of use. It is useful to have a function to provide this in igraph. The proposed function would achieve this with a concise API and added functionality.

This is in the spirit of the Flexibility design principle I recently proposed: don't just return the result in the most naïve/simple form; instead enable users to do as many different things as possible with the result of the computation.