### PR TITLE
fix: shortest path crash with zero-length weight vector

### DIFF
--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -5826,7 +5826,7 @@ PyObject *igraphmodule_Graph_shortest_paths(igraphmodule_GraphObject * self,
       }
     }
   } else {
-    /* No weights, use a simple BFS */
+    /* No weights or empty weight vector, use a simple BFS */
     e = igraph_shortest_paths(&self->g, &res, from_vs, to_vs, mode);
   }
 

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -5808,7 +5808,7 @@ PyObject *igraphmodule_Graph_shortest_paths(igraphmodule_GraphObject * self,
   }
 
   /* Select the most suitable algorithm */
-  if (weights) {
+  if (weights && igraph_vector_size(weights) > 0) {
     if (igraph_vector_min(weights) > 0) {
       /* Only positive weights, use Dijkstra's algorithm */
       e = igraph_shortest_paths_dijkstra(&self->g, &res, from_vs, to_vs, weights, mode);


### PR DESCRIPTION
Fixes #513.

This is trivial, but I'm not yet comfortable directly committing to python-igraph