### PR TITLE
Don't generate the pydoctor sidebar

### DIFF
--- a/scripts/mkdoc.sh
+++ b/scripts/mkdoc.sh
@@ -44,11 +44,16 @@ rm -f dist/*.whl && .venv/bin/pip install .
 IGRAPHDIR=`.venv/bin/python3 -c 'import igraph, os; print(os.path.dirname(igraph.__file__))'`
 
 echo "Generating HTML documentation..."
+
+# Using --no-sidebar option to skip the sidebar whole together not to generate noise in the HTML.
+# Because the pydoctor output is integrated in a smaller div with a custom CSS it's not optimal to include the sidebar.
+
 "$PYDOCTOR" \
     --project-name "igraph" \
     --project-url "https://igraph.org/python" \
     --introspect-c-modules \
     --make-html \
+    --no-sidebar \
     --html-output "${DOC_API_FOLDER}/html" \
 	${IGRAPHDIR}
 


### PR DESCRIPTION
The API documentation is currently not optimal, the sidebar is shown inline the main contents because the CSS is customized and integrated in a smaller div.

Skipping the sidebar generation is probably the best, to avoid this:

<img width="316" alt="by default 2022-07-12 at 4 20 06 PM" src="https://user-images.githubusercontent.com/19967168/178587529-a80609dc-a448-41b3-a984-3c4341a01ea4.png">