### PR TITLE
networkx g.nodes is not a list but is iterable

### DIFF
--- a/src/igraph/io/libraries.py
+++ b/src/igraph/io/libraries.py
@@ -98,7 +98,7 @@ def _construct_graph_from_networkx(cls, g, vertex_attr_hashable : str = "_nx_nam
     vcount = len(vnames)
 
     # Dictionary connecting networkx hashables with igraph indices
-    if len(g) and "_igraph_index" in g.nodes[0]:
+    if len(g) and "_igraph_index" in next(iter(g.nodes)):
         # Collect _igraph_index and fill gaps
         idx = [x["_igraph_index"] for v, x in g.nodes.data()]
         idx.sort()

--- a/src/igraph/io/libraries.py
+++ b/src/igraph/io/libraries.py
@@ -98,7 +98,7 @@ def _construct_graph_from_networkx(cls, g, vertex_attr_hashable : str = "_nx_nam
     vcount = len(vnames)
 
     # Dictionary connecting networkx hashables with igraph indices
-    if len(g) and "_igraph_index" in next(iter(g.nodes)):
+    if len(g) and "_igraph_index" in next(iter(g.nodes.values())):
         # Collect _igraph_index and fill gaps
         idx = [x["_igraph_index"] for v, x in g.nodes.data()]
         idx.sort()

--- a/src/igraph/io/libraries.py
+++ b/src/igraph/io/libraries.py
@@ -118,7 +118,7 @@ def _construct_graph_from_networkx(cls, g, vertex_attr_hashable : str = "_nx_nam
 
     # Vertex attributes
     for v, datum in g.nodes.data():
-        for key, val in list(datum.items()):
+        for key, val in datum.items():
             # Get rid of _igraph_index (we used it already)
             if key == "_igraph_index":
                 continue

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -690,6 +690,17 @@ class ForeignTests(unittest.TestCase):
         self.assertEqual(g.vcount(), g2.vcount())
         self.assertEqual(sorted(g.get_edgelist()), sorted(g2.get_edgelist()))
 
+        # Test networkx with custom node hashables
+        # In this case each node is a tuple of ints
+        g_nx = nx.DiGraph()
+        g_nx.add_edges_from((
+            ((0, 0), (1, 1), {"weight": 3.0}),
+            ((0, 0), (1, 0), {"weight": float("inf")}),
+        ))
+        g = Graph.from_networkx(g_nx)
+        self.assertTrue(g.is_directed())
+        self.assertEqual(g.vcount(), 2)
+
     @unittest.skipIf(nx is None, "test case depends on networkx")
     def testMultigraphNetworkx(self):
         # Undirected

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -693,13 +693,15 @@ class ForeignTests(unittest.TestCase):
         # Test networkx with custom node hashables
         # In this case each node is a tuple of ints
         g_nx = nx.DiGraph()
+        inf = float("inf")
         g_nx.add_edges_from((
             ((0, 0), (1, 1), {"weight": 3.0}),
-            ((0, 0), (1, 0), {"weight": float("inf")}),
+            ((0, 0), (1, 0), {"weight": inf}),
         ))
         g = Graph.from_networkx(g_nx)
         self.assertTrue(g.is_directed())
-        self.assertEqual(g.vcount(), 2)
+        self.assertEqual(g.vcount(), 3)
+        self.assertTrue(g.es["weight"] == [3.0, inf] or g.es["weight"] == [inf, 3.0])
 
     @unittest.skipIf(nx is None, "test case depends on networkx")
     def testMultigraphNetworkx(self):


### PR DESCRIPTION
Aiming at fixing #566.

We should add a test to this one before merging.