### PR TITLE
Fix #587 via better docs and logic and add test

### DIFF
--- a/src/igraph/drawing/__init__.py
+++ b/src/igraph/drawing/__init__.py
@@ -236,7 +236,7 @@ def plot(obj, target=None, bbox=(0, 0, 600, 600), *args, **kwds):
             palette = palettes[palette]
 
         if isinstance(target, (str, Path)):
-            save_path = target
+            save_path = str(target)
             target = None
         else:
             save_path = None

--- a/tests/drawing/matplotlib/test_graph.py
+++ b/tests/drawing/matplotlib/test_graph.py
@@ -4,6 +4,8 @@ import unittest
 
 from igraph import Graph, InternalError, plot, VertexClustering, config
 
+from ...utils import overridden_configuration
+
 # FIXME: find a better way to do this that works for both direct call and module
 # import e.g. tox
 try:
@@ -84,11 +86,8 @@ class GraphTestRunner(unittest.TestCase):
     def test_gh_587(self):
         plt.close("all")
         g = Graph.Ring(5)
-        config['plotting.backend'] = 'matplotlib'
-        try:
+        with overridden_configuration('plotting.backend', 'matplotlib'):
             plot(g, target="graph_basic.png", layout=self.layout_small_ring)
-        finally:
-            config['plotting.backend'] = 'cairo'
 
 
 class ClusteringTestRunner(unittest.TestCase):

--- a/tests/drawing/matplotlib/test_graph.py
+++ b/tests/drawing/matplotlib/test_graph.py
@@ -2,7 +2,7 @@ import random
 import unittest
 
 
-from igraph import Graph, InternalError, plot, VertexClustering
+from igraph import Graph, InternalError, plot, VertexClustering, config
 
 # FIXME: find a better way to do this that works for both direct call and module
 # import e.g. tox
@@ -79,6 +79,16 @@ class GraphTestRunner(unittest.TestCase):
         dot = ax.get_children()[0]
         dot.set_facecolor("blue")
         dot.radius *= 0.5
+
+    @image_comparison(baseline_images=["graph_basic"], remove_text=True)
+    def test_gh_587(self):
+        plt.close("all")
+        g = Graph.Ring(5)
+        config['plotting.backend'] = 'matplotlib'
+        try:
+            plot(g, target="graph_basic.png", layout=self.layout_small_ring)
+        finally:
+            config['plotting.backend'] = 'cairo'
 
 
 class ClusteringTestRunner(unittest.TestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,6 +11,18 @@ __all__ = ("temporary_file", )
 
 
 @contextmanager
+def overridden_configuration(key, value):
+    from igraph import config
+
+    old_value = config[key]
+    config[key] = value
+    try:
+        yield
+    finally:
+        config[key] = old_value
+
+
+@contextmanager
 def temporary_file(content=None, mode=None, binary=False):
     tmpf, tmpfname = tempfile.mkstemp()
     os.close(tmpf)


### PR DESCRIPTION
This PR aims at fixing #587.

- Improved the docstring
- Added logic if the user specified a file-like target with a non-cairo backend
- Added test for this exact situation.

It works on my machine, both in practice and as a unit test.