### PR TITLE
Adapt Python interface to new UMAP changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changed
+
+- UMAP layout now exposes the computation of the symmetrized edge weights via
+  `umap_compute_weights()`. The layout function, `Graph.layout_umap()`, can
+  now be called either on a directed graph with edge distances, or on an
+  undirected graph with edge weights, typically computed via
+  `umap_compute_weights()` or precomputed by the user. Moreover, the
+  `sampling_prob` argument was faulty and has been removed. See PR
+  [#613](https://github.com/igraph/python-igraph/pull/613) for details.
+
 ### Fixed
 
 - `Graph.Data_Frame()` now handles the `Int64` data type from `pandas`, thanks

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -15616,17 +15616,54 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
    "Internal function, undocumented.\n\n"
    "@see: Graph.layout_sugiyama()\n\n"},
 
+  /* interface to igraph_layout_umap_compute_weights */
+  {"layout_umap_compute_weights",
+   (PyCFunction) igraphmodule_Graph_layout_umap_compute_weights,
+   METH_VARARGS | METH_KEYWORDS,
+   "layout_umap_compute_weights(dist)\n"
+   "--\n\n"
+   "@param dist: distances associated with the graph edges.\n"
+   "@return: Symmetrized weights associated with each edge. If the distance\n"
+   "  graph has both directed edges between a pair of vertices, one of the\n"
+   "  returned weights will be set to zero.\n\n"
+   "Compute undirected UMAP weights from directed distance graph.\n\n"
+   "UMAP is a layout algorithm that usually takes as input a directed\n"
+   "distance graph, e.g. a k nearest neighbor graph based on Euclidean\n"
+   "distance between points in a vector space. The graph is directed\n"
+   "because vertex v1 might consider vertex v2 a close neighbor, but v2\n"
+   "itself might have many neighbors that are closer than v1.\n"
+   "This function computes the symmetrized weights from the distance graph\n"
+   "using union as the symmetry operator. In simple terms, if either vertex\n"
+   "considers the other a close neighbor, they will be treated as close\n"
+   "neighbors.\n\n"
+   "This function can be used as a separate preprocessing step to\n"
+   "Graph.layout_umap(). For efficiency reasons, the returned weights have the\n"
+   "same length as the input distances, however because of the symmetryzation\n"
+   "some information is lost. Therefore, the weight of one of the edges is set\n"
+   "to zero whenever edges in opposite directions are found in the input\n"
+   "distance graph. You can pipe the output of this function directly into\n"
+   "Graph.layout_umap() as follows:\n"
+   "C{weights = graph.layout_umap_compute_weights(dist)}\n"
+   "C{layout = graph.layout_umap(weights=weights)}\n\n"
+   "@see: Graph.layout_umap()\n\n"},
+
   /* interface to igraph_layout_umap */
   {"layout_umap",
    (PyCFunction) igraphmodule_Graph_layout_umap,
    METH_VARARGS | METH_KEYWORDS,
-   "layout_umap(dist=None, dim=2, seed=None, min_dist=0.01, epochs=500)\n"
+   "layout_umap(dist=None, weights=None, dim=2, seed=None, min_dist=0.01, epochs=500)\n"
    "--\n\n"
    "Uniform Manifold Approximation and Projection (UMAP).\n\n"
    "This layout is a probabilistic algorithm that places vertices that are connected\n"
    "and have a short distance close by in the embedded space.\n\n"
    "@param dist: distances associated with the graph edges. If None, all edges will\n"
-   "  be assumed to convey the same distance between the vertices.\n"
+   "  be assumed to convey the same distance between the vertices. Either this\n"
+   "  argument of the C{weights} argument can be set, but not both. It is fine to\n"
+   "  set neither.\n"
+   "@param weights: precomputed edge weights if you have them, as an alternative\n"
+   "  to setting the C{dist} argument. Zero weights will be ignored if this\n"
+   "  argument is set, e.g. if you computed the weights via\n"
+   "  Graph.layout_umap_compute_weights().\n"
    "@param dim: the desired number of dimensions for the layout. dim=2\n"
    "  means a 2D layout, dim=3 means a 3D layout.\n"
    "@param seed: if C{None}, uses a random starting layout for the\n"
@@ -15640,9 +15677,17 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
    "  Notice that UMAP does not technically converge for symmetry reasons, but a\n"
    "  larger number of epochs should generally give an equivalent or better layout.\n"
    "@return: the calculated layout.\n\n"
+   "Please note that if distances are set, the graph is usually directed, whereas\n"
+   "if weights are precomputed, the graph will be treated as undirected. A special\n"
+   "case is when the graph is directed but the precomputed weights are symmetrized\n"
+   "in a way only one of each pair of opposite edges has nonzero weight, e.g. as\n"
+   "computed by Graph.layout_umap_compute_weights(). For example:\n"
+   "C{weights = graph.layout_umap_compute_weights(dist)}\n"
+   "C{layout = graph.layout_umap(weights=weights)}\n\n"
    "@newfield ref: Reference\n"
    "@ref: L McInnes, J Healy, J Melville: UMAP: Uniform Manifold Approximation\n"
-   "  and Projection for Dimension Reduction. arXiv:1802.03426."},
+   "  and Projection for Dimension Reduction. arXiv:1802.03426.\n"
+   "@see: Graph.layout_umap_compute_weights()\n\n"},
 
   ////////////////////////////
   // VISITOR-LIKE FUNCTIONS //

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -8150,7 +8150,7 @@ PyObject *igraphmodule_Graph_layout_umap(
  * \return the weights given that graph
  * \sa igraph_layout_umap_compute_weights
  */
-PyObject *igraphmodule_Graph_layout_umap(
+PyObject *igraphmodule_Graph_layout_umap_compute_weights(
     igraphmodule_GraphObject * self, PyObject * args, PyObject * kwds)
 {
   static char *kwlist[] =
@@ -8183,7 +8183,7 @@ PyObject *igraphmodule_Graph_layout_umap(
   }
 
   /* Call the function */
-  if (igraph_layout_umap_compute_weights(graph, dist, &weights)) {
+  if (igraph_layout_umap_compute_weights(&self->g, dist, &weights)) {
       igraph_vector_destroy(&weights);
       igraph_vector_destroy(dist); free(dist);
       PyErr_NoMemory();

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -8145,58 +8145,6 @@ PyObject *igraphmodule_Graph_layout_umap(
   return (PyObject *) result_o;
 }
 
-/** \ingroup python_interface_graph
- * \brief Compute weights for Uniform Manifold Approximation and Projection (UMAP)
- * \return the weights given that graph
- * \sa igraph_layout_umap_compute_weights
- */
-PyObject *igraphmodule_Graph_layout_umap_compute_weights(
-    igraphmodule_GraphObject * self, PyObject * args, PyObject * kwds)
-{
-  static char *kwlist[] = { "dist", NULL };
-  igraph_vector_t *dist = 0;
-  igraph_vector_t weights;
-  PyObject *dist_o = Py_None;
-  PyObject *result_o;
-
-  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &dist_o))
-    return NULL;
-
-  /* Initialize distances */
-  if (dist_o != Py_None) {
-    dist = (igraph_vector_t*)malloc(sizeof(igraph_vector_t));
-    if (!dist) {
-      PyErr_NoMemory();
-      return NULL;
-    }
-    if (igraphmodule_PyObject_to_vector_t(dist_o, dist, 0)) {
-      free(dist);
-      return NULL;
-    }
-  }
-
-  /* Initialize weights */
-  if (igraph_vector_init(&weights, 0)) {
-      igraph_vector_destroy(dist); free(dist);
-      PyErr_NoMemory();
-      return NULL;
-  }
-
-  /* Call the function */
-  if (igraph_layout_umap_compute_weights(&self->g, dist, &weights)) {
-      igraph_vector_destroy(&weights);
-      igraph_vector_destroy(dist); free(dist);
-      PyErr_NoMemory();
-      return NULL;
-  }
-  igraph_vector_destroy(dist); free(dist);
-
-  /* Convert output to Python list */
-  result_o = igraphmodule_vector_t_to_PyList(&weights, IGRAPHMODULE_TYPE_FLOAT);
-  igraph_vector_destroy(&weights);
-  return (PyObject *) result_o;
-}
-
 
 /** \ingroup python_interface_graph
  * \brief Places the vertices of a bipartite graph according to a simple two-layer
@@ -15691,37 +15639,6 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
    "Internal function, undocumented.\n\n"
    "@see: Graph.layout_sugiyama()\n\n"},
 
-  /* interface to igraph_layout_umap_compute_weights */
-  {"layout_umap_compute_weights",
-   (PyCFunction) igraphmodule_Graph_layout_umap_compute_weights,
-   METH_VARARGS | METH_KEYWORDS,
-   "layout_umap_compute_weights(dist)\n"
-   "--\n\n"
-   "@param dist: distances associated with the graph edges.\n"
-   "@return: Symmetrized weights associated with each edge. If the distance\n"
-   "  graph has both directed edges between a pair of vertices, one of the\n"
-   "  returned weights will be set to zero.\n\n"
-   "Compute undirected UMAP weights from directed distance graph.\n\n"
-   "UMAP is a layout algorithm that usually takes as input a directed\n"
-   "distance graph, e.g. a k nearest neighbor graph based on Euclidean\n"
-   "distance between points in a vector space. The graph is directed\n"
-   "because vertex v1 might consider vertex v2 a close neighbor, but v2\n"
-   "itself might have many neighbors that are closer than v1.\n"
-   "This function computes the symmetrized weights from the distance graph\n"
-   "using union as the symmetry operator. In simple terms, if either vertex\n"
-   "considers the other a close neighbor, they will be treated as close\n"
-   "neighbors.\n\n"
-   "This function can be used as a separate preprocessing step to\n"
-   "Graph.layout_umap(). For efficiency reasons, the returned weights have the\n"
-   "same length as the input distances, however because of the symmetryzation\n"
-   "some information is lost. Therefore, the weight of one of the edges is set\n"
-   "to zero whenever edges in opposite directions are found in the input\n"
-   "distance graph. You can pipe the output of this function directly into\n"
-   "Graph.layout_umap() as follows:\n"
-   "C{weights = graph.layout_umap_compute_weights(dist)}\n"
-   "C{layout = graph.layout_umap(weights=weights)}\n\n"
-   "@see: Graph.layout_umap()\n\n"},
-
   /* interface to igraph_layout_umap */
   {"layout_umap",
    (PyCFunction) igraphmodule_Graph_layout_umap,
@@ -15738,7 +15655,7 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
    "@param weights: precomputed edge weights if you have them, as an alternative\n"
    "  to setting the C{dist} argument. Zero weights will be ignored if this\n"
    "  argument is set, e.g. if you computed the weights via\n"
-   "  Graph.layout_umap_compute_weights().\n"
+   "  igraph.layout_umap_compute_weights().\n"
    "@param dim: the desired number of dimensions for the layout. dim=2\n"
    "  means a 2D layout, dim=3 means a 3D layout.\n"
    "@param seed: if C{None}, uses a random starting layout for the\n"
@@ -15756,13 +15673,13 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
    "if weights are precomputed, the graph will be treated as undirected. A special\n"
    "case is when the graph is directed but the precomputed weights are symmetrized\n"
    "in a way only one of each pair of opposite edges has nonzero weight, e.g. as\n"
-   "computed by Graph.layout_umap_compute_weights(). For example:\n"
-   "C{weights = graph.layout_umap_compute_weights(dist)}\n"
+   "computed by igraph.layout_umap_compute_weights(). For example:\n"
+   "C{weights = igraph.layout_umap_compute_weights(graph, dist)}\n"
    "C{layout = graph.layout_umap(weights=weights)}\n\n"
    "@newfield ref: Reference\n"
    "@ref: L McInnes, J Healy, J Melville: UMAP: Uniform Manifold Approximation\n"
    "  and Projection for Dimension Reduction. arXiv:1802.03426.\n"
-   "@see: Graph.layout_umap_compute_weights()\n\n"},
+   "@see: igraph.layout_umap_compute_weights()\n\n"},
 
   ////////////////////////////
   // VISITOR-LIKE FUNCTIONS //

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -8153,8 +8153,7 @@ PyObject *igraphmodule_Graph_layout_umap(
 PyObject *igraphmodule_Graph_layout_umap_compute_weights(
     igraphmodule_GraphObject * self, PyObject * args, PyObject * kwds)
 {
-  static char *kwlist[] =
-    { "dist", NULL };
+  static char *kwlist[] = { "dist", NULL };
   igraph_vector_t *dist = 0;
   igraph_vector_t weights;
   PyObject *dist_o = Py_None;
@@ -8174,6 +8173,7 @@ PyObject *igraphmodule_Graph_layout_umap_compute_weights(
       free(dist);
       return NULL;
     }
+  }
 
   /* Initialize weights */
   if (igraph_vector_init(&weights, 0)) {
@@ -8195,7 +8195,6 @@ PyObject *igraphmodule_Graph_layout_umap_compute_weights(
   result_o = igraphmodule_vector_t_to_PyList(&weights, IGRAPHMODULE_TYPE_FLOAT);
   igraph_vector_destroy(&weights);
   return (PyObject *) result_o;
-  
 }
 
 

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -71,6 +71,7 @@ from igraph._igraph import (
     set_progress_handler,
     set_random_number_generator,
     set_status_handler,
+    umap_compute_weights,
     __igraph_version__,
 )
 from igraph.adjacency import (
@@ -963,7 +964,7 @@ Graph._layout_mapping = _layout_mapping
 for name in dir(Graph):
     if not name.startswith("layout_"):
         continue
-    if name in ("layout_auto", "layout_sugiyama", "layout_umap_compute_weights"):
+    if name in ("layout_auto", "layout_sugiyama"):
         continue
     setattr(Graph, name, _layout_method_wrapper(getattr(Graph, name)))
 

--- a/src/igraph/__init__.py
+++ b/src/igraph/__init__.py
@@ -963,7 +963,7 @@ Graph._layout_mapping = _layout_mapping
 for name in dir(Graph):
     if not name.startswith("layout_"):
         continue
-    if name in ("layout_auto", "layout_sugiyama"):
+    if name in ("layout_auto", "layout_sugiyama", "layout_umap_compute_weights"):
         continue
     setattr(Graph, name, _layout_method_wrapper(getattr(Graph, name)))
 

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -1,6 +1,7 @@
 import unittest
 from math import hypot
 from igraph import Graph, Layout, BoundingBox, InternalError
+from igraph import umap_compute_weights
 
 
 class LayoutTests(unittest.TestCase):
@@ -324,7 +325,7 @@ class LayoutAlgorithmTests(unittest.TestCase):
         dist = [1, 1.5, 1.8, 2.0, 3.4, 0.5]
         # NOTE: you need a directed graph to make sense of the symmetryzation
         g = Graph(edges, directed=True)
-        weights = g.layout_umap_compute_weights(dist)
+        weights = umap_compute_weights(g, dist)
         self.assertEqual(
             weights,
             [1.0, 1.0, 1.0, 1.1253517471925912e-07, 6.14421235332821e-06, 0.0])

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -318,6 +318,17 @@ class LayoutAlgorithmTests(unittest.TestCase):
         lo_adj = g.layout_umap(dist=dist, epochs=1, seed=lo.coords)
         self.assertTrue(isinstance(lo_adj, Layout))
 
+    def testUMAPComputeWeights(self):
+        edges = [0, 1, 0, 2, 1, 2, 1, 3, 2, 3, 2, 0]
+        edges = list(zip(edges[::2], edges[1::2]))
+        dist = [1, 1.5, 1.8, 2.0, 3.4, 0.5]
+        # NOTE: you need a directed graph to make sense of the symmetryzation
+        g = Graph(edges, directed=True)
+        weights = g.layout_umap_compute_weights(dist)
+        self.assertEqual(
+            weights,
+            [1.0, 1.0, 1.0, 1.1253517471925912e-07, 6.14421235332821e-06, 0.0])
+
     def testLGL(self):
         g = Graph.Barabasi(100)
         lo = g.layout("lgl")


### PR DESCRIPTION
Started adapting the Python interface to the new UMAP API changes:
- [x] Write docs for new compute_weight function
- [x] Adapt docs of current UMAP function
- [x] Write interface code for new compute_weight function
- [x] Adapt code of current UMAP function
- [x] Compiles locally
- [x] Write tests
- [x] Pass tests locally
- [x] Pass CI
- [x] Move the weight function to a separate function instead of a `Graph` method
- [x] changelog

Ready for review. The docs are a little sketchy still so if someone could take a look and rephrase that'd help.