### PR TITLE
Handle pandas dataframe with non-comparable data types

### DIFF
--- a/src/igraph/io/objects.py
+++ b/src/igraph/io/objects.py
@@ -459,7 +459,7 @@ def _construct_graph_from_dataframe(
 
         # Bring DataFrame(s) into same format as with 'use_vids=True'
         if vertices is None:
-            vertices = pd.DataFrame({"name": np.unique(edges.values[:, :2])})
+            vertices = pd.DataFrame({"name": pd.unique(edges.values[:, :2].ravel())})
 
         if vertices.iloc[:, 0].isna().any():
             warn(

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -522,6 +522,11 @@ class GeneratorTests(unittest.TestCase):
         g = Graph.DataFrame(edges)
         self.assertTrue(g.vcount() == 3)
 
+        # dataframe with both int data and str data
+        edges = pd.DataFrame({"source": [1, 2, 2], "target": ["A", "B", "A"]})
+        g = Graph.DataFrame(edges, use_vids=False)
+        self.assertTrue(g.vs["name"] == [1, "A", 2, "B"])
+
         # Invalid input
         with self.assertRaisesRegex(ValueError, "two columns"):
             edges = pd.DataFrame({"source": [1, 2, 3]})


### PR DESCRIPTION
The following produces an error:
```
import igraph as ig
import pandas as pd

d = {'col1': [1, 2, 2], 'col2': ["a", "b", "c"]}
df = pd.DataFrame(data=d)
g = ig.Graph.DataFrame(df, directed=True, use_vids=False)
```

The error message:
```
TypeError                                 Traceback (most recent call last)
Cell In [1], line 6
      4 d = {'col1': [1, 2, 2], 'col2': ["a", "b", "c"]}
      5 df = pd.DataFrame(data=d)
----> 6 g = ig.Graph.DataFrame(df, directed=True, use_vids=False)

File ~/.pyenv/versions/3.11.0/lib/python3.11/site-packages/igraph/io/objects.py:455, in _construct_graph_from_dataframe(cls, edges, directed, vertices, use_vids)
    453 # Bring DataFrame(s) into same format as with 'use_vids=True'
    454 if vertices is None:
--> 455     vertices = pd.DataFrame({"name": np.unique(edges.values[:, :2])})
    457 if vertices.iloc[:, 0].isna().any():
    458     warn(
    459         "In the first column of 'vertices' NA elements were replaced with string \"NA\""
    460     )

File <__array_function__ internals>:180, in unique(*args, **kwargs)

File ~/.pyenv/versions/3.11.0/lib/python3.11/site-packages/numpy/lib/arraysetops.py:274, in unique(ar, return_index, return_inverse, return_counts, axis, equal_nan)
    272 ar = np.asanyarray(ar)
    273 if axis is None:
--> 274     ret = _unique1d(ar, return_index, return_inverse, return_counts,
    275                     equal_nan=equal_nan)
    276     return _unpack_tuple(ret)
    278 # axis was specified and not None

File ~/.pyenv/versions/3.11.0/lib/python3.11/site-packages/numpy/lib/arraysetops.py:336, in _unique1d(ar, return_index, return_inverse, return_counts, equal_nan)
    334     aux = ar[perm]
    335 else:
--> 336     ar.sort()
    337     aux = ar
    338 mask = np.empty(aux.shape, dtype=np.bool_)

TypeError: '<' not supported between instances of 'str' and 'int'
```

This is caused by `numpy.unique()` tries to sort the names of the vertices.
I believe the sorting is not necessary here, so this can be fixed by replacing `numpy.unique()` by `pandas.unique()`

I have also added a test for graph generation from a dataframe with non-comparable data types.

