### PR TITLE
Add Python 3.11 classifier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,7 +294,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.11.0-rc.2'
+          python-version: '3.11'
 
       - name: Build C core
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 [![Build and test with tox](https://github.com/igraph/python-igraph/actions/workflows/build.yml/badge.svg)](https://github.com/igraph/python-igraph/actions/workflows/build.yml)
-[![PyPI pyversions](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue)](https://pypi.python.org/pypi/igraph)
+[![PyPI pyversions](https://img.shields.io/pypi/pyversions/igraph)](https://pypi.python.org/pypi/igraph)
 [![PyPI wheels](https://img.shields.io/pypi/wheel/igraph.svg)](https://pypi.python.org/pypi/igraph)
 [![Documentation Status](https://readthedocs.org/projects/igraph/badge/?version=latest)](https://igraph.readthedocs.io/)
 

--- a/setup.py
+++ b/setup.py
@@ -985,6 +985,7 @@ options = dict(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Information Analysis",


### PR DESCRIPTION
Hi,

when I tried out `igraph` for one of our projects I was not sure, if you support Python 3.11, because the classifier was missing and the badge also didn't indicate it. Therefore I did some adjustments 🙂 

- Added Python 3.11 classifier to `setup.py`
- Adjusted the Python version version badge to atomically grab the supported versions from `pypi`, which are set via the classifiers
- Set Python version for 3.11 from RC to GA in GitHub workflow