### PR TITLE
split aarch64 build into manylinux and musllinux to prevent GHA timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,8 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
-  build_wheel_linux_aarch64:
-    name: Build wheels on Linux (aarch64)
+  build_wheel_linux_aarch64_manylinux:
+    name: Build wheels on Linux (aarch64/manylinux)
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
@@ -68,6 +68,24 @@ jobs:
           CIBW_BEFORE_BUILD: "yum install -y flex bison libxml2-devel zlib-devel && pip install -U cmake pip wheel && python setup.py build_c_core"
           CIBW_ARCHS_LINUX: aarch64
           CIBW_BUILD: "*-manylinux_aarch64"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_wheel_linux_aarch64_musllinux:
+    name: Build wheels on Linux (aarch64/musllinux)
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v2
 
       - name: Build wheels (musllinux)
         uses: pypa/cibuildwheel@v2.12.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
   build_wheel_linux_aarch64_manylinux:
     name: Build wheels on Linux (aarch64/manylinux)
     runs-on: ubuntu-20.04
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v3
         with:
@@ -75,6 +76,7 @@ jobs:
   build_wheel_linux_aarch64_musllinux:
     name: Build wheels on Linux (aarch64/musllinux)
     runs-on: ubuntu-20.04
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,6 @@ jobs:
   build_wheel_linux_aarch64_manylinux:
     name: Build wheels on Linux (aarch64/manylinux)
     runs-on: ubuntu-20.04
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v3
         with:
@@ -76,7 +75,6 @@ jobs:
   build_wheel_linux_aarch64_musllinux:
     name: Build wheels on Linux (aarch64/musllinux)
     runs-on: ubuntu-20.04
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
@ntamas as suggested I split the `aarch64` build into 2 to prevent GHA timeout after 6 hours, which is currently quite tight and even timed out.