### PR TITLE
update install.rst

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -50,7 +50,7 @@ Package managers on Linux and other systems
 -------------------------------------------
 |igraph|'s Python interface and its dependencies are included in several package management
 systems, including those of the most popular Linux distributions (Arch Linux,
-Debian and Ubuntu, Fedora, GNU Guix, etc.) as well as some cross-platform systems like
+Debian and Ubuntu, Fedora, etc.) as well as some cross-platform systems like
 NixPkgs or MacPorts.
 
 .. note:: |igraph| is updated quite often: if you need a more recent version than your


### PR DESCRIPTION
I would rather not promote GUIX. It is not a popular distro (so let's not call it that) and despite repeated warnings, they make grossly intrusive and risky changes to igraph, some of which are obviously harmful. For example, they enforce 64-bit integers on 32-bit platforms, reducing performance and increasing memory usage, for the sake of "unbundling" of libraries.

https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/graph.scm#n115