### PR TITLE
Update from deprecated PyCObject to PyCapsule

### DIFF
--- a/src/_igraph/igraphmodule_api.h
+++ b/src/_igraph/igraphmodule_api.h
@@ -56,25 +56,8 @@ extern "C" {
 
   /* Return -1 and set exception on error, 0 on success */
   static int import_igraph(void) {
-    PyObject *c_api_object;
-    PyObject *module;
-
-    module = PyImport_ImportModule("igraph._igraph");
-    if (module == 0)
-      return -1;
-
-    c_api_object = PyObject_GetAttrString(module, "_C_API");
-    if (c_api_object == 0) {
-      Py_DECREF(module);
-      return -1;
-    }
-
-    if (PyCObject_Check(c_api_object))
-      PyIGraph_API = (void**)PyCObject_AsVoidPtr(c_api_object);
-
-    Py_DECREF(c_api_object);
-    Py_DECREF(module);
-    return 0;
+    PyIGraph_API = (void **)PyCapsule_Import("igraph._igraph._C_API", 0);
+    return (PyIGraph_API != NULL) ? 0 : -1;
   }
 
 #endif


### PR DESCRIPTION
I was trying to use python-igraph's api and got compiler warnings for implicit declaration of `PyCObject_Check` and `PyCObject_AsVoidPtr`. The [CObject api has been deprecated](https://python.readthedocs.io/en/v2.7.2/c-api/cobject.html). It looks like this got updated elsewhere but missed in `igraphmodule_api.h`. Pretty much just copied from the [Providing a C API for an Extension Module](https://python.readthedocs.io/en/stable/extending/extending.html#using-capsules) example. Changing to my branch fixes the previous errors I was getting with the missing `PyCObject_*` symbols.
