### PR TITLE
feat: `is_clique()` and `is_independent_vertex_set()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
  - Added `Graph.Hypercube()` for creating n-dimensional hypercube graphs.
  - Added `Graph.Chung_Lu()` for sampling from the Chung-Lu model as well as several related models.
  - Added `Graph.is_complete()` to test if there is a connection between all distinct pairs of vertices.
+ - Added `Graph.is_clique()` to test if a set of vertices forms a clique.
+ - Added `Graph.is_independent_vertex_set()` to test if some vertices form an independent set.
  - Added `Graph.mean_degree()` for a convenient way to compute the average degree of a graph.
 
 ### Changed

--- a/src/_igraph/graphobject.c
+++ b/src/_igraph/graphobject.c
@@ -568,6 +568,77 @@ PyObject *igraphmodule_Graph_is_complete(igraphmodule_GraphObject* self, PyObjec
 
 
 /** \ingroup python_interface_graph
+ * \brief Checks whether a given vertex set forms a clique
+ */
+PyObject *igraphmodule_Graph_is_clique(igraphmodule_GraphObject * self,
+                                       PyObject * args, PyObject * kwds)
+{
+  PyObject *list = Py_None;
+  PyObject *directed = Py_False;
+  igraph_bool_t res;
+  igraph_vs_t vs;
+
+  static char *kwlist[] = { "vertices", "directed", NULL };
+
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OO", kwlist, &list, &directed)) {
+    return NULL;
+  }
+
+  if (igraphmodule_PyObject_to_vs_t(list, &vs, &self->g, NULL, NULL)) {
+    return NULL;
+  }
+
+  if (igraph_is_clique(&self->g, vs, PyObject_IsTrue(directed), &res)) {
+    igraphmodule_handle_igraph_error();
+    igraph_vs_destroy(&vs);
+    return NULL;
+  }
+
+  igraph_vs_destroy(&vs);
+
+  if (res)
+    Py_RETURN_TRUE;
+  else
+    Py_RETURN_FALSE;
+}
+
+
+/** \ingroup python_interface_graph
+ * \brief Checks whether a the given vertices form an independent set
+ */
+PyObject *igraphmodule_Graph_is_independent_vertex_set(igraphmodule_GraphObject * self,
+                                       PyObject * args, PyObject * kwds)
+{
+  PyObject *list = Py_None;
+  igraph_bool_t res;
+  igraph_vs_t vs;
+
+  static char *kwlist[] = { "vertices", NULL };
+
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kwlist, &list)) {
+    return NULL;
+  }
+
+  if (igraphmodule_PyObject_to_vs_t(list, &vs, &self->g, NULL, NULL)) {
+    return NULL;
+  }
+
+  if (igraph_is_independent_vertex_set(&self->g, vs, &res)) {
+    igraphmodule_handle_igraph_error();
+    igraph_vs_destroy(&vs);
+    return NULL;
+  }
+
+  igraph_vs_destroy(&vs);
+
+  if (res)
+    Py_RETURN_TRUE;
+  else
+    Py_RETURN_FALSE;
+}
+
+
+/** \ingroup python_interface_graph
  * \brief Determines whether a graph is a (directed or undirected) tree
  * \sa igraph_is_tree
  */
@@ -13767,6 +13838,22 @@ struct PyMethodDef igraphmodule_Graph_methods[] = {
    "ordered pairs are considered.\n\n"
    "@return: C{True} if it is complete, C{False} otherwise.\n"
    "@rtype: boolean"},
+
+  {"is_clique", (PyCFunction) igraphmodule_Graph_is_clique,
+   METH_VARARGS | METH_KEYWORDS,
+   "is_clique(vertices=None, directed=False)\n--\n\n"
+   "Decides whether a set of vertices is a clique, i.e. a fully connected subgraph.\n\n"
+   "@param vertices: a list of vertex IDs.\n"
+   "@param directed: whether to require mutual connections between vertex pairs\n"
+   "    in directed graphs.\n"
+   "@return: C{True} is the given vertex set is a clique, C{False} if not.\n"},
+
+  {"is_independent_vertex_set", (PyCFunction) igraphmodule_Graph_is_independent_vertex_set,
+   METH_VARARGS | METH_KEYWORDS,
+   "is_independent_vertex_set(vertices=None)\n--\n\n"
+   "Decides whether no two vertices within a set are adjacent.\n\n"
+   "@param vertices: a list of vertex IDs.\n"
+   "@return: C{True} is the given vertices form an independent set, C{False} if not.\n"},
 
   /* interface to igraph_is_tree */
   {"is_tree", (PyCFunction) igraphmodule_Graph_is_tree,

--- a/tests/test_cliques.py
+++ b/tests/test_cliques.py
@@ -66,12 +66,14 @@ class CliqueTests(unittest.TestCase):
         self.assertEqual(
             sorted(map(sorted, self.g.largest_cliques())), [[1, 2, 3, 4], [1, 2, 4, 5]]
         )
+        self.assertTrue(all(map(self.g.is_clique, self.g.largest_cliques())))
 
     def testMaximalCliques(self):
         self.assertEqual(
             sorted(map(sorted, self.g.maximal_cliques())),
             [[0, 3, 4], [0, 4, 5], [1, 2, 3, 4], [1, 2, 4, 5]],
         )
+        self.assertTrue(all(map(self.g.is_clique, self.g.maximal_cliques())))
         self.assertEqual(
             sorted(map(sorted, self.g.maximal_cliques(min=4))),
             [[1, 2, 3, 4], [1, 2, 4, 5]],
@@ -136,6 +138,7 @@ class IndependentVertexSetTests(unittest.TestCase):
         self.assertEqual(
             self.g1.largest_independent_vertex_sets(), [(0, 3, 4), (2, 3, 4)]
         )
+        self.assertTrue(all(map(self.g1.is_independent_vertex_set, self.g1.largest_independent_vertex_sets())))
 
     def testMaximalIndependentVertexSets(self):
         self.assertEqual(
@@ -152,6 +155,7 @@ class IndependentVertexSetTests(unittest.TestCase):
                 (2, 4, 7, 8),
             ],
         )
+        self.assertTrue(all(map(self.g2.is_independent_vertex_set, self.g2.maximal_independent_vertex_sets())))
 
     def testIndependenceNumber(self):
         self.assertEqual(self.g2.independence_number(), 6)


### PR DESCRIPTION
One question is whether we should drop `is_complete()` from Python now that `g.is_clique()` (with no parameters) performs the same function, and dispatches to the same C function.

Perhaps just keep it for discoverability?