### PR TITLE
Explicitly require cmake as a build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ requires = [
     # Workaround based on this commit:
     # https://github.com/harfbuzz/uharfbuzz/commit/9b607bd06fb17fcb4abe3eab5c4f342ad08309d7
     "setuptools>=64,<72.2.0; platform_python_implementation == 'PyPy'",
-    "setuptools>=64; platform_python_implementation != 'PyPy'"
+    "setuptools>=64; platform_python_implementation != 'PyPy'",
+    "cmake>=3.18"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
As discussed in the review of #804 , this PR again includes that change, which was required on my device to get Python to compile this library.