### PR TITLE
setup.py: import bdist_wheel from setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
-    "wheel",
     # pin setuptools:
     # https://github.com/airspeed-velocity/asv/pull/1426#issuecomment-2290658198
     # Most likely cause:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if sys.version_info < (3, 9):
 from setuptools import find_packages, setup, Command, Extension
 
 try:
-    from wheel.bdist_wheel import bdist_wheel
+    from setuptools.command.bdist_wheel import bdist_wheel
 except ImportError:
     bdist_wheel = None
 


### PR DESCRIPTION
This PR removes the direct dependency from `wheel` and imports `bdist_wheel` from setuptools instead. This change is motivated by https://github.com/pypa/setuptools/pull/4647. 

Other libs have done similar changes as this PR https://github.com/yaml/pyyaml/pull/823/files.

Disclaimer: I am not a python developer. I am just trying to fix a piece of software that depends on igraph and broke when being built in an environment with more recent dependency versions.