### PR TITLE
docs: do not save the config in gallery example

### DIFF
--- a/doc/examples_sphinx-gallery/configuration.py
+++ b/doc/examples_sphinx-gallery/configuration.py
@@ -18,16 +18,16 @@ ig.config["plotting.layout"] = "fruchterman_reingold"
 ig.config["plotting.palette"] = "rainbow"
 
 # %%
-# Then, we save them. By default, ``ig.config.save()`` will save files to
-# ``~/.igraphrc`` on Linux and Max OS X systems, or in
-# ``%USERPROFILE%\.igraphrc`` for Windows systems:
-ig.config.save()
+# The updated configuration affects only the current session. Optionally, it
+# can be saved using ``ig.config.save()``. By default, this function writes the
+# configuration to ``~/.igraphrc`` on Linux and Max OS X systems, and in
+# ``%USERPROFILE%\.igraphrc`` on Windows systems.
 
 # %%
-# The code above only needs to be run once (to store the new config options
-# into the ``.igraphrc`` file). Whenever you use igraph and this file exists,
-# igraph will read its content and use those options as defaults. For
-# example, let's create and plot a new graph to demonstrate:
+# The configuration only needs to be saved to `.igraphrc` once, and it will
+# be automatically used in all future sessions. Whenever you use igraph and
+# this file exists, igraph will read its content and use those options as
+# defaults. For example, let's create and plot a new graph to demonstrate:
 random.seed(1)
 g = ig.Graph.Barabasi(n=100, m=1)
 


### PR DESCRIPTION
because building the docs overwrites one's config
and potentially causes issues, including unexpected tests outputs.

