### PR TITLE
Fix incorrect `Py_XDECREF/Py_DECREF` call on stolen reference after `PyList_SetItem` failure

### DIFF
--- a/src/_igraph/attributes.c
+++ b/src/_igraph/attributes.c
@@ -282,7 +282,6 @@ PyObject* igraphmodule_i_create_edge_attribute(const igraph_t* graph,
     Py_INCREF(Py_None);
     if (PyList_SetItem(values, i, Py_None)) {  /* reference stolen */
       Py_DECREF(values);
-      Py_DECREF(Py_None);
       return 0;
     }
   }
@@ -659,7 +658,6 @@ static igraph_error_t igraphmodule_i_attribute_add_vertices(
 
       if (o) {
         if (PyList_SetItem(value, i + j, o)) {
-          Py_DECREF(o); /* append failed */
           o = NULL; /* indicate error */
         } else {
           /* reference stolen by the list */
@@ -721,7 +719,6 @@ static igraph_error_t igraphmodule_i_attribute_permute_vertices(const igraph_t *
       Py_INCREF(o);
       if (PyList_SetItem(newlist, i, o)) {
         PyErr_PrintEx(0);
-        Py_DECREF(o);
         Py_DECREF(newlist);
         Py_DECREF(newdict);
         IGRAPH_ERROR("", IGRAPH_FAILURE);
@@ -878,7 +875,6 @@ static igraph_error_t igraphmodule_i_attribute_add_edges(
 
       if (o) {
         if (PyList_SetItem(value, i + j, o)) {
-          Py_DECREF(o); /* append failed */
           o = NULL; /* indicate error */
         } else {
           /* reference stolen by the list */
@@ -935,7 +931,6 @@ static igraph_error_t igraphmodule_i_attribute_permute_edges(const igraph_t *gra
       Py_INCREF(o);
       if (PyList_SetItem(newlist, i, o)) {
         PyErr_PrintEx(0);
-        Py_DECREF(o);
         Py_DECREF(newlist);
         Py_DECREF(newdict);
         IGRAPH_ERROR("", IGRAPH_FAILURE);
@@ -982,7 +977,6 @@ static PyObject* igraphmodule_i_ac_func(PyObject* values,
       Py_INCREF(item);
 
       if (PyList_SetItem(list, j, item)) {   /* reference to item stolen */
-        Py_DECREF(item);
         Py_DECREF(res);
         return 0;
       }
@@ -1070,7 +1064,6 @@ static PyObject* igraphmodule_i_ac_sum(PyObject* values,
 
     item = PyFloat_FromDouble(sum);
     if (PyList_SetItem(res, i, item)) {   /* reference to item stolen */
-      Py_DECREF(item);
       Py_DECREF(res);
       return 0;
     }
@@ -1114,7 +1107,6 @@ static PyObject* igraphmodule_i_ac_prod(PyObject* values,
     /* reference to new float stolen */
     item = PyFloat_FromDouble((double)prod);
     if (PyList_SetItem(res, i, item)) {   /* reference to item stolen */
-      Py_DECREF(item);
       Py_DECREF(res);
       return 0;
     }
@@ -1147,7 +1139,6 @@ static PyObject* igraphmodule_i_ac_first(PyObject* values,
 
     Py_INCREF(item);
     if (PyList_SetItem(res, i, item)) {  /* reference to item stolen */
-      Py_DECREF(item);
       Py_DECREF(res);
       return 0;
     }
@@ -1207,7 +1198,6 @@ static PyObject* igraphmodule_i_ac_random(PyObject* values,
 
     Py_INCREF(item);
     if (PyList_SetItem(res, i, item)) {  /* reference to item stolen */
-      Py_DECREF(item);
       Py_DECREF(random_func);
       Py_DECREF(res);
       return 0;
@@ -1244,7 +1234,6 @@ static PyObject* igraphmodule_i_ac_last(PyObject* values,
     Py_INCREF(item);
 
     if (PyList_SetItem(res, i, item)) {   /* reference to item stolen */
-      Py_DECREF(item);
       Py_DECREF(res);
       return 0;
     }
@@ -1290,7 +1279,6 @@ static PyObject* igraphmodule_i_ac_mean(PyObject* values,
     /* reference to new float stolen */
     item = PyFloat_FromDouble((double)mean);
     if (PyList_SetItem(res, i, item)) {   /* reference to item stolen */
-      Py_DECREF(item);
       Py_DECREF(res);
       return 0;
     }
@@ -1324,7 +1312,6 @@ static PyObject* igraphmodule_i_ac_median(PyObject* values,
 
       Py_INCREF(item);
       if (PyList_SetItem(list, j, item)) {  /* reference to item stolen */
-        Py_DECREF(item);
         Py_DECREF(list);
         Py_DECREF(res);
         return 0;
@@ -1383,7 +1370,6 @@ static PyObject* igraphmodule_i_ac_median(PyObject* values,
 
     /* reference to item stolen */
     if (PyList_SetItem(res, i, item)) {
-      Py_DECREF(item);
       Py_DECREF(list);
       Py_DECREF(res);
       return 0;

--- a/src/_igraph/edgeobject.c
+++ b/src/_igraph/edgeobject.c
@@ -393,7 +393,6 @@ int igraphmodule_Edge_set_attribute(igraphmodule_EdgeObject* self, PyObject* k, 
      * It took me 1.5 hours between London and Manchester to figure it out */
     Py_INCREF(v);
     r=PyList_SetItem(result, self->idx, v);
-    if (r == -1) { Py_DECREF(v); }
     return r;
   }
 
@@ -406,7 +405,6 @@ int igraphmodule_Edge_set_attribute(igraphmodule_EdgeObject* self, PyObject* k, 
       if (i != self->idx) {
         Py_INCREF(Py_None);
         if (PyList_SetItem(result, i, Py_None) == -1) {
-          Py_DECREF(Py_None);
           Py_DECREF(result);
           return -1;
         }
@@ -414,7 +412,6 @@ int igraphmodule_Edge_set_attribute(igraphmodule_EdgeObject* self, PyObject* k, 
         /* Same game with the reference count here */
         Py_INCREF(v);
         if (PyList_SetItem(result, i, v) == -1) {
-          Py_DECREF(v);
           Py_DECREF(result);
           return -1;
         }

--- a/src/_igraph/edgeseqobject.c
+++ b/src/_igraph/edgeseqobject.c
@@ -310,7 +310,6 @@ PyObject* igraphmodule_EdgeSeq_get_attribute_values(igraphmodule_EdgeSeqObject* 
         Py_INCREF(item);
 
         if (PyList_SetItem(result, i, item)) {
-          Py_DECREF(item);
           Py_DECREF(result);
           return 0;
         }
@@ -335,7 +334,6 @@ PyObject* igraphmodule_EdgeSeq_get_attribute_values(igraphmodule_EdgeSeqObject* 
         Py_INCREF(item);
 
         if (PyList_SetItem(result, i, item)) {
-          Py_DECREF(item);
           Py_DECREF(result);
           return 0;
         }
@@ -359,7 +357,6 @@ PyObject* igraphmodule_EdgeSeq_get_attribute_values(igraphmodule_EdgeSeqObject* 
         Py_INCREF(item);
 
         if (PyList_SetItem(result, i, item)) {
-          Py_DECREF(item);
           Py_DECREF(result);
           return 0;
         }
@@ -495,7 +492,6 @@ int igraphmodule_EdgeSeq_set_attribute_values_mapping(igraphmodule_EdgeSeqObject
         }
         /* No need to Py_INCREF(item), PySequence_GetItem returns a new reference */
         if (PyList_SetItem(list, i, item)) {
-          Py_DECREF(item);
           return -1;
         } /* PyList_SetItem stole a reference to the item automatically */
       }
@@ -516,7 +512,6 @@ int igraphmodule_EdgeSeq_set_attribute_values_mapping(igraphmodule_EdgeSeqObject
         }
         /* No need to Py_INCREF(item), PySequence_GetItem returns a new reference */
         if (PyList_SetItem(list, i, item)) {
-          Py_DECREF(item);
           Py_DECREF(list);
           return -1;
         }
@@ -560,7 +555,6 @@ int igraphmodule_EdgeSeq_set_attribute_values_mapping(igraphmodule_EdgeSeqObject
         }
         /* No need to Py_INCREF(item), PySequence_GetItem returns a new reference */
         if (PyList_SetItem(list, VECTOR(es)[i], item)) {
-          Py_DECREF(item);
           igraph_vector_int_destroy(&es);
           return -1;
         } /* PyList_SetItem stole a reference to the item automatically */
@@ -579,7 +573,6 @@ int igraphmodule_EdgeSeq_set_attribute_values_mapping(igraphmodule_EdgeSeqObject
       for (i = 0; i < n2; i++) {
         Py_INCREF(Py_None);
         if (PyList_SetItem(list, i, Py_None)) {
-          Py_DECREF(Py_None);
           Py_DECREF(list);
           return -1;
         }
@@ -596,7 +589,6 @@ int igraphmodule_EdgeSeq_set_attribute_values_mapping(igraphmodule_EdgeSeqObject
         }
         /* No need to Py_INCREF(item), PySequence_GetItem returns a new reference */
         if (PyList_SetItem(list, VECTOR(es)[i], item)) {
-          Py_DECREF(item);
           Py_DECREF(list);
           return -1;
         }

--- a/src/_igraph/indexing.c
+++ b/src/_igraph/indexing.c
@@ -340,7 +340,6 @@ static int igraphmodule_i_Graph_adjmatrix_set_index_row(igraph_t* graph,
           /* Setting attribute */
           Py_INCREF(item);
           if (PyList_SetItem(values, eid, item)) {
-            Py_DECREF(item);
             igraph_vector_int_clear(&data->to_add);
           }
         }
@@ -402,7 +401,6 @@ static int igraphmodule_i_Graph_adjmatrix_set_index_row(igraph_t* graph,
           /* Setting attribute */
           Py_INCREF(new_value);
           if (PyList_SetItem(values, eid, new_value)) {
-            Py_DECREF(new_value);
             igraph_vector_int_clear(&data->to_add);
           }
         }

--- a/src/_igraph/operators.c
+++ b/src/_igraph/operators.c
@@ -156,7 +156,6 @@ PyObject *igraphmodule__union(PyObject *self,
           if (!dest || PyList_SetItem(emi, j, dest)) {
             igraph_vector_ptr_destroy(&gs);
             igraph_vector_int_list_destroy(&edgemaps);
-            Py_XDECREF(dest);
             Py_DECREF(emi);
             Py_DECREF(em_list);
             return NULL;
@@ -167,7 +166,6 @@ PyObject *igraphmodule__union(PyObject *self,
       if (!emi || PyList_SetItem(em_list, i, emi)) {
         igraph_vector_ptr_destroy(&gs);
         igraph_vector_int_list_destroy(&edgemaps);
-        Py_XDECREF(emi);
         Py_DECREF(em_list);
         return NULL;
       }
@@ -281,7 +279,6 @@ PyObject *igraphmodule__intersection(PyObject *self,
           if (!dest || PyList_SetItem(emi, j, dest)) {
             igraph_vector_ptr_destroy(&gs);
             igraph_vector_int_list_destroy(&edgemaps);
-            Py_XDECREF(dest);
             Py_DECREF(emi);
             Py_DECREF(em_list);
             return NULL;
@@ -292,7 +289,6 @@ PyObject *igraphmodule__intersection(PyObject *self,
       if (!emi || PyList_SetItem(em_list, i, emi)) {
         igraph_vector_ptr_destroy(&gs);
         igraph_vector_int_list_destroy(&edgemaps);
-        Py_XDECREF(emi);
         Py_DECREF(em_list);
         return NULL;
       }

--- a/src/_igraph/pyhelpers.c
+++ b/src/_igraph/pyhelpers.c
@@ -84,10 +84,9 @@ PyObject* igraphmodule_PyList_NewFill(Py_ssize_t len, PyObject* item) {
 	for (i = 0; i < len; i++) {
 		Py_INCREF(item);
 		if (PyList_SetItem(result, i, item)) {
-      Py_DECREF(item);
-      Py_DECREF(result);
-      return 0;
-    }
+          Py_DECREF(result);
+          return 0;
+        }
 	}
 
 	return result;

--- a/src/_igraph/vertexobject.c
+++ b/src/_igraph/vertexobject.c
@@ -524,7 +524,6 @@ int igraphmodule_Vertex_set_attribute(igraphmodule_VertexObject* self, PyObject*
      * It took me 1.5 hours between London and Manchester to figure it out */
     Py_INCREF(v);
     r=PyList_SetItem(result, self->idx, v);
-    if (r == -1) { Py_DECREF(v); }
     return r;
   }
 
@@ -537,7 +536,6 @@ int igraphmodule_Vertex_set_attribute(igraphmodule_VertexObject* self, PyObject*
       if (i != self->idx) {
         Py_INCREF(Py_None);
         if (PyList_SetItem(result, i, Py_None) == -1) {
-          Py_DECREF(Py_None);
           Py_DECREF(result);
           return -1;
         }
@@ -545,7 +543,6 @@ int igraphmodule_Vertex_set_attribute(igraphmodule_VertexObject* self, PyObject*
         /* Same game with the reference count here */
         Py_INCREF(v);
         if (PyList_SetItem(result, i, v) == -1) {
-          Py_DECREF(v);
           Py_DECREF(result);
           return -1;
         }
@@ -639,7 +636,6 @@ static PyObject* _convert_to_edge_list(igraphmodule_VertexObject* vertex, PyObje
     }
 
     if (PyList_SetItem(obj, i, edge)) {  /* reference to v stolen, reference to idx discarded */
-      Py_DECREF(edge);
       return NULL;
     }
   }
@@ -684,7 +680,6 @@ static PyObject* _convert_to_vertex_list(igraphmodule_VertexObject* vertex, PyOb
     }
 
     if (PyList_SetItem(obj, i, v)) {  /* reference to v stolen, reference to idx discarded */
-      Py_DECREF(v);
       return NULL;
     }
   }

--- a/src/_igraph/vertexseqobject.c
+++ b/src/_igraph/vertexseqobject.c
@@ -295,7 +295,6 @@ PyObject* igraphmodule_VertexSeq_get_attribute_values(igraphmodule_VertexSeqObje
         Py_INCREF(item);
 
         if (PyList_SetItem(result, i, item)) {
-          Py_DECREF(item);
           Py_DECREF(result);
           return 0;
         }
@@ -320,7 +319,6 @@ PyObject* igraphmodule_VertexSeq_get_attribute_values(igraphmodule_VertexSeqObje
         Py_INCREF(item);
 
         if (PyList_SetItem(result, i, item)) {
-          Py_DECREF(item);
           Py_DECREF(result);
           return 0;
         }
@@ -343,7 +341,6 @@ PyObject* igraphmodule_VertexSeq_get_attribute_values(igraphmodule_VertexSeqObje
         Py_INCREF(item);
 
         if (PyList_SetItem(result, i, item)) {
-          Py_DECREF(item);
           Py_DECREF(result);
           return 0;
         }
@@ -469,7 +466,6 @@ int igraphmodule_VertexSeq_set_attribute_values_mapping(igraphmodule_VertexSeqOb
         if (item == 0) return -1;
         /* No need to Py_INCREF(item), PySequence_GetItem returns a new reference */
         if (PyList_SetItem(list, i, item)) {
-          Py_DECREF(item);
           return -1;
         } /* PyList_SetItem stole a reference to the item automatically */
       }
@@ -487,7 +483,6 @@ int igraphmodule_VertexSeq_set_attribute_values_mapping(igraphmodule_VertexSeqOb
         }
         /* No need to Py_INCREF(item), PySequence_GetItem returns a new reference */
         if (PyList_SetItem(list, i, item)) {
-          Py_DECREF(item);
           Py_DECREF(list);
           return -1;
         }
@@ -530,7 +525,6 @@ int igraphmodule_VertexSeq_set_attribute_values_mapping(igraphmodule_VertexSeqOb
         }
         /* No need to Py_INCREF(item), PySequence_GetItem returns a new reference */
         if (PyList_SetItem(list, VECTOR(vs)[i], item)) {
-          Py_DECREF(item);
           igraph_vector_int_destroy(&vs);
           return -1;
         } /* PyList_SetItem stole a reference to the item automatically */
@@ -549,7 +543,6 @@ int igraphmodule_VertexSeq_set_attribute_values_mapping(igraphmodule_VertexSeqOb
       for (i = 0; i < n2; i++) {
         Py_INCREF(Py_None);
         if (PyList_SetItem(list, i, Py_None)) {
-          Py_DECREF(Py_None);
           Py_DECREF(list);
           igraph_vector_int_destroy(&vs);
           return -1;
@@ -566,7 +559,6 @@ int igraphmodule_VertexSeq_set_attribute_values_mapping(igraphmodule_VertexSeqOb
         }
         /* No need to Py_INCREF(item), PySequence_GetItem returns a new reference */
         if (PyList_SetItem(list, VECTOR(vs)[i], item)) {
-          Py_DECREF(list);
           Py_DECREF(item);
           igraph_vector_int_destroy(&vs);
           return -1;


### PR DESCRIPTION
<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->

<!-- The following text must be left intact and the box checked before the PR can be merged. -->

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

Close #884 